### PR TITLE
feat(toc): add chapter link to table of contents

### DIFF
--- a/src/components/reader/BookTableOfContents.astro
+++ b/src/components/reader/BookTableOfContents.astro
@@ -1,10 +1,12 @@
 ---
-import type { Audience } from "../../config/site";
+import type { Audience, Locale } from "../../config/site";
 import type { TocGroup } from "../../lib/content/toc";
+import { buildChapterReaderHref } from "../../lib/content/chapter-routes";
 
 type ChapterAudience = Audience | "all";
 
 interface Props {
+  lang: Locale;
   bookTitle: string;
   bookSubtitle?: string;
   tocLabel: string;
@@ -12,7 +14,7 @@ interface Props {
   audienceLabels: Record<ChapterAudience, string>;
 }
 
-const { bookTitle, bookSubtitle, tocLabel, groups, audienceLabels } =
+const { lang, bookTitle, bookSubtitle, tocLabel, groups, audienceLabels } =
   Astro.props as Props;
 ---
 
@@ -51,7 +53,14 @@ const { bookTitle, bookSubtitle, tocLabel, groups, audienceLabels } =
                     {entry.data.chapterTitle}
                   </p>
 
-                  <h3 class="book-toc-entry__title">{entry.data.pageTitle}</h3>
+                  <h3 class="book-toc-entry__title">
+                    <a
+                      class="book-toc-entry__link"
+                      href={buildChapterReaderHref(lang, entry)}
+                    >
+                      {entry.data.pageTitle}
+                    </a>
+                  </h3>
 
                   <p class="book-toc-entry__summary">{entry.data.summary}</p>
 
@@ -170,6 +179,18 @@ const { bookTitle, bookSubtitle, tocLabel, groups, audienceLabels } =
   .book-toc-entry__title {
     margin: 0;
     font-size: 1.2rem;
+  }
+
+  .book-toc-entry__link {
+    color: var(--heading-color);
+    text-decoration: none;
+  }
+
+  .book-toc-entry__link:hover {
+    color: var(--accent-primary-strong);
+    text-decoration: underline;
+    text-decoration-thickness: 0.08rem;
+    text-underline-offset: 0.2rem;
   }
 
   .book-toc-entry__summary {

--- a/src/lib/content/chapter-routes.ts
+++ b/src/lib/content/chapter-routes.ts
@@ -1,0 +1,16 @@
+import type { ChapterEntry } from "./chapters";
+import type { Locale } from "../../config/site";
+import { BOOK_HOME_SEGMENT } from "./toc-conventions";
+
+function trimSlashes(path: string): string {
+  return path.replace(/^\/+|\/+$/g, "");
+}
+
+export function buildChapterReaderHref(
+  lang: Locale,
+  chapter: ChapterEntry,
+): string {
+  const slug = trimSlashes(chapter.data.slug);
+
+  return `/${lang}/${BOOK_HOME_SEGMENT}/${slug}/`;
+}

--- a/src/lib/content/toc-conventions.ts
+++ b/src/lib/content/toc-conventions.ts
@@ -4,6 +4,9 @@ export const BOOK_HOME_SEGMENT = "book" as const;
 
 export const BOOK_HOME_ROUTE_PATTERN = `/{lang}/${BOOK_HOME_SEGMENT}/` as const;
 
+export const CHAPTER_READER_ROUTE_PATTERN =
+  `/{lang}/${BOOK_HOME_SEGMENT}/{slug}/` as const;
+
 export const TOC_SCOPE = {
   book: MVP_BOOK_ID,
   localeMode: "active-only",

--- a/src/pages/[lang]/book/index.astro
+++ b/src/pages/[lang]/book/index.astro
@@ -96,6 +96,7 @@ const audienceOptions = AUDIENCES.map((audience) => ({
     audienceOptions={audienceOptions}
   />
   <BookTableOfContents
+    lang={lang}
     bookTitle={bookTitle}
     bookSubtitle={bookSubtitle}
     tocLabel={tocLabel}


### PR DESCRIPTION
## Summary

Adds correct link generation for Table of Contents entries.

This introduces a central chapter route helper and uses it to make each TOC entry title point to the future chapter reader destination.

## Changes

- Adds `buildChapterReaderHref`
- Documents the future chapter reader route pattern
- Passes the active locale into `BookTableOfContents`
- Renders TOC entry titles as links
- Keeps Phase 5 reader implementation deferred

## Scope boundaries

This PR intentionally does not implement:

- chapter reader routes
- MDX page rendering
- current-chapter sidebar
- previous/next chapter navigation
- heading anchors
- glossary interactions

Clicking a TOC entry may still lead to a 404 until Phase 5 implements the reader route.

## Verification

- [X] `npm run typecheck`
- [X] `npm run lint`
- [X] `npm run build`
- [X] Manually checked `/en/book/`
- [X] Manually checked `/pt-BR/book/`
- [X] Confirmed English TOC links point to `/en/book/.../`
- [X] Confirmed PT-BR TOC links point to `/pt-BR/book/.../`

Closes #54