### PR TITLE
feat(toc): add book home empty states

### DIFF
--- a/src/components/reader/BookTableOfContents.astro
+++ b/src/components/reader/BookTableOfContents.astro
@@ -12,10 +12,24 @@ interface Props {
   tocLabel: string;
   groups: TocGroup[];
   audienceLabels: Record<ChapterAudience, string>;
+  emptyStateTitle: string;
+  emptyStateBody: string;
+  emptyGroupLabel: string;
 }
 
-const { lang, bookTitle, bookSubtitle, tocLabel, groups, audienceLabels } =
-  Astro.props as Props;
+const {
+  lang,
+  bookTitle,
+  bookSubtitle,
+  tocLabel,
+  groups,
+  audienceLabels,
+  emptyStateTitle,
+  emptyStateBody,
+  emptyGroupLabel,
+} = Astro.props as Props;
+
+const hasTocEntries = groups.some((group) => group.entries.length > 0);
 ---
 
 <section class="book-toc" aria-labelledby="book-toc-title">
@@ -26,61 +40,74 @@ const { lang, bookTitle, bookSubtitle, tocLabel, groups, audienceLabels } =
     {bookSubtitle && <p class="book-toc__subtitle">{bookSubtitle}</p>}
   </header>
 
-  <div class="book-toc__groups">
-    {
-      groups.map((group) => (
-        <section
-          class="book-toc__group"
-          aria-labelledby={`toc-group-${group.id}`}
-        >
-          <header class="book-toc__group-header">
-            <h2 id={`toc-group-${group.id}`}>{group.label}</h2>
+  {
+    hasTocEntries ? (
+      <div class="book-toc__groups">
+        {groups.map((group) => (
+          <section
+            class="book-toc__group"
+            aria-labelledby={`toc-group-${group.id}`}
+          >
+            <header class="book-toc__group-header">
+              <h2 id={`toc-group-${group.id}`}>{group.label}</h2>
 
-            {group.description && (
-              <p class="book-toc__group-description">{group.description}</p>
+              {group.description && (
+                <p class="book-toc__group-description">{group.description}</p>
+              )}
+            </header>
+
+            {group.entries.length > 0 ? (
+              <ol class="book-toc__entries">
+                {group.entries.map((entry, entryIndex) => (
+                  <li class="book-toc-entry">
+                    <span class="book-toc-entry__number">
+                      {String(entryIndex + 1).padStart(2, "0")}
+                    </span>
+
+                    <div class="book-toc-entry__body">
+                      <p class="book-toc-entry__chapter">
+                        {entry.data.chapterTitle}
+                      </p>
+
+                      <h3 class="book-toc-entry__title">
+                        <a
+                          class="book-toc-entry__link"
+                          href={buildChapterReaderHref(lang, entry)}
+                        >
+                          {entry.data.pageTitle}
+                        </a>
+                      </h3>
+
+                      <p class="book-toc-entry__summary">
+                        {entry.data.summary}
+                      </p>
+
+                      <div class="book-toc-entry__meta">
+                        <span class="book-toc-entry__meta-item">
+                          {audienceLabels[entry.data.audience]}
+                        </span>
+
+                        <span class="book-toc-entry__meta-item">
+                          {entry.data.status}
+                        </span>
+                      </div>
+                    </div>
+                  </li>
+                ))}
+              </ol>
+            ) : (
+              <p class="book-toc__group-empty">{emptyGroupLabel}</p>
             )}
-          </header>
-
-          <ol class="book-toc__entries">
-            {group.entries.map((entry, entryIndex) => (
-              <li class="book-toc-entry">
-                <span class="book-toc-entry__number">
-                  {String(entryIndex + 1).padStart(2, "0")}
-                </span>
-
-                <div class="book-toc-entry__body">
-                  <p class="book-toc-entry__chapter">
-                    {entry.data.chapterTitle}
-                  </p>
-
-                  <h3 class="book-toc-entry__title">
-                    <a
-                      class="book-toc-entry__link"
-                      href={buildChapterReaderHref(lang, entry)}
-                    >
-                      {entry.data.pageTitle}
-                    </a>
-                  </h3>
-
-                  <p class="book-toc-entry__summary">{entry.data.summary}</p>
-
-                  <div class="book-toc-entry__meta">
-                    <span class="book-toc-entry__meta-item">
-                      {audienceLabels[entry.data.audience]}
-                    </span>
-
-                    <span class="book-toc-entry__meta-item">
-                      {entry.data.status}
-                    </span>
-                  </div>
-                </div>
-              </li>
-            ))}
-          </ol>
-        </section>
-      ))
-    }
-  </div>
+          </section>
+        ))}
+      </div>
+    ) : (
+      <div class="book-toc__empty" role="status">
+        <h2>{emptyStateTitle}</h2>
+        <p>{emptyStateBody}</p>
+      </div>
+    )
+  }
 </section>
 
 <style>
@@ -134,6 +161,15 @@ const { lang, bookTitle, bookSubtitle, tocLabel, groups, audienceLabels } =
 
   .book-toc__group-description {
     margin: 0;
+  }
+
+  .book-toc__group-empty {
+    margin: 0;
+    padding: var(--space-4);
+    border: 1px dashed var(--border-color);
+    border-radius: var(--radius-sm);
+    color: var(--muted-text-color);
+    background: rgba(10, 15, 20, 0.24);
   }
 
   .book-toc__entries {
@@ -195,6 +231,22 @@ const { lang, bookTitle, bookSubtitle, tocLabel, groups, audienceLabels } =
 
   .book-toc-entry__summary {
     margin: var(--space-2) 0 0;
+  }
+
+  .book-toc__empty {
+    padding: var(--space-5);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-md);
+    background: rgba(31, 41, 55, 0.34);
+  }
+
+  .book-toc__empty h2 {
+    margin: 0 0 var(--space-2);
+    font-size: clamp(1.25rem, 1rem + 1vw, 1.6rem);
+  }
+
+  .book-toc__empty p {
+    margin: 0;
   }
 
   .book-toc-entry__meta {

--- a/src/pages/[lang]/book/index.astro
+++ b/src/pages/[lang]/book/index.astro
@@ -58,6 +58,10 @@ const pageCopy = {
     heading: "Book Home",
     body: "Browse the current book structure and choose where to start reading.",
     tocLabel: "Table of Contents",
+    emptyStateTitle: "No chapters available yet",
+    emptyStateBody:
+      "This book does not have published chapter entries for the current language yet.",
+    emptyGroupLabel: "No entries are available in this group yet.",
     languageSwitcherLabel: "Language",
     audienceSwitcherLabel: "Audience",
   },
@@ -67,6 +71,10 @@ const pageCopy = {
     heading: "Home do Livro",
     body: "Explore a estrutura atual do livro e escolha por onde começar a leitura.",
     tocLabel: "Sumário",
+    emptyStateTitle: "Ainda não há capítulos disponíveis",
+    emptyStateBody:
+      "Este livro ainda não tem capítulos publicados para o idioma atual.",
+    emptyGroupLabel: "Ainda não há entradas disponíveis neste grupo.",
     languageSwitcherLabel: "Idioma",
     audienceSwitcherLabel: "Público",
   },
@@ -102,6 +110,9 @@ const audienceOptions = AUDIENCES.map((audience) => ({
     tocLabel={tocLabel}
     groups={tocGroups}
     audienceLabels={audienceLabels[lang]}
+    emptyStateTitle={copy.emptyStateTitle}
+    emptyStateBody={copy.emptyStateBody}
+    emptyGroupLabel={copy.emptyGroupLabel}
   />
 
   <script>


### PR DESCRIPTION
## Summary

Adds empty-state and missing-data safeguards to the book home Table of Contents.

This keeps the book home understandable when chapter content is missing, incomplete, or temporarily unavailable.

## Changes

- Adds a general empty state when no TOC entries are available
- Adds a group-level empty message for groups without entries
- Passes localized empty-state copy into `BookTableOfContents`
- Keeps TOC rendering safe for sparse or incomplete content data

## Scope boundaries

This PR intentionally does not implement:

- chapter reader routes
- MDX page rendering
- refined book-home copy
- orientation/breadcrumb cues
- responsive layout refinements
- Phase 5 reader behavior

## Verification

- [X] `npm run typecheck`
- [X] `npm run lint`
- [X] `npm run build`
- [X] Manually checked `/en/book/`
- [X] Manually checked `/pt-BR/book/`
- [X] Temporarily tested empty TOC behavior and removed the temporary change before commit

Closes #55