### PR TITLE
chore(toc): refine book home labels and copy

### DIFF
--- a/src/content/config/core.en.json
+++ b/src/content/config/core.en.json
@@ -2,7 +2,7 @@
   "book": "core",
   "lang": "en",
   "bookTitle": "Return of the Night",
-  "bookSubtitle": "Placeholder Core Book Configuration",
+  "bookSubtitle": "Browse the current core book structure and choose where to start reading.",
   "navigation": {
     "tableOfContents": "Table of Contents",
     "previousChapter": "Previous Chapter",
@@ -12,8 +12,8 @@
   "chapterGroups": [
     {
       "id": "test-group",
-      "label": "Test Group",
-      "description": "Placeholder chapter group used to validate book configuration loading.",
+      "label": "Opening Material",
+      "description": "Introductory and early reference material for the current book draft.",
       "order": 0,
       "chapterNumbers": [0]
     }

--- a/src/pages/[lang]/book/index.astro
+++ b/src/pages/[lang]/book/index.astro
@@ -40,12 +40,12 @@ const tocGroups = groupOrderedChapterEntriesForToc(
 
 const audienceLabels = {
   en: {
-    all: "All readers",
+    all: "Player and GM",
     player: "Player",
     gm: "GM",
   },
   "pt-BR": {
-    all: "Todos",
+    all: "Jogador e Mestre",
     player: "Jogador",
     gm: "Mestre",
   },
@@ -53,30 +53,31 @@ const audienceLabels = {
 
 const pageCopy = {
   en: {
-    title: "Return of the Night Book",
-    description: "The book home for Return of the Night",
-    heading: "Book Home",
-    body: "Browse the current book structure and choose where to start reading.",
+    title: "Return of the Night — Table of Contents",
+    description:
+      "Browse the current Table of Contents for the Return of the Night core book.",
+    heading: "Return of the Night",
+    body: "Browse the current core book structure and choose where to start reading.",
     tocLabel: "Table of Contents",
     emptyStateTitle: "No chapters available yet",
     emptyStateBody:
-      "This book does not have published chapter entries for the current language yet.",
-    emptyGroupLabel: "No entries are available in this group yet.",
+      "This book does not have chapter entries for the current language yet.",
+    emptyGroupLabel: "No entries are available in this section yet.",
     languageSwitcherLabel: "Language",
-    audienceSwitcherLabel: "Audience",
+    audienceSwitcherLabel: "Reading Mode",
   },
   "pt-BR": {
-    title: "Livro de Return of the Night",
-    description: "A página inicial do livro de Return of the Night",
-    heading: "Home do Livro",
-    body: "Explore a estrutura atual do livro e escolha por onde começar a leitura.",
+    title: "Return of the Night — Sumário",
+    description:
+      "Explore o sumário atual do livro principal de Return of the Night.",
+    heading: "Return of the Night",
+    body: "Explore a estrutura atual do livro principal e escolha por onde começar a leitura.",
     tocLabel: "Sumário",
     emptyStateTitle: "Ainda não há capítulos disponíveis",
-    emptyStateBody:
-      "Este livro ainda não tem capítulos publicados para o idioma atual.",
-    emptyGroupLabel: "Ainda não há entradas disponíveis neste grupo.",
+    emptyStateBody: "Este livro ainda não tem capítulos para o idioma atual.",
+    emptyGroupLabel: "Ainda não há entradas disponíveis nesta seção.",
     languageSwitcherLabel: "Idioma",
-    audienceSwitcherLabel: "Público",
+    audienceSwitcherLabel: "Modo de Leitura",
   },
 } as const;
 


### PR DESCRIPTION
## Summary

Refines the visible labels and copy on the book home Table of Contents page.

This removes remaining placeholder/debug-style wording and makes the page language better fit the current reader direction while staying within Phase 4 scope.

## Changes

- Refines English and PT-BR book home page copy
- Updates audience labels to better describe the reading mode
- Removes “published/publicados” wording from empty states
- Updates the English core book configuration subtitle
- Replaces placeholder group copy in `core.en.json`

## Scope boundaries

This PR intentionally does not implement:

- global i18n infrastructure
- breadcrumbs or orientation UI
- responsive layout refinements
- chapter reader routes
- MDX page rendering
- Phase 5 reader behavior

## Verification

- [X] `npm run typecheck`
- [X] `npm run lint`
- [X] `npm run build`
- [X] Manually checked `/en/book/`
- [X] Manually checked `/pt-BR/book/`

Closes #56