### PR TITLE
feat(reader): define reader conventions

### DIFF
--- a/src/lib/content/reader-conventions.ts
+++ b/src/lib/content/reader-conventions.ts
@@ -1,0 +1,67 @@
+import { MVP_BOOK_ID } from "./conventions";
+import {
+  BOOK_HOME_SEGMENT,
+  CHAPTER_READER_ROUTE_PATTERN,
+} from "./toc-conventions";
+
+// The reader must complete the chapter path already promised by the Table of Contents.
+// Do not introduce a parallel reader route unless the TOC contract changes first.
+export const READER_ROUTE = {
+  segment: BOOK_HOME_SEGMENT,
+  pattern: CHAPTER_READER_ROUTE_PATTERN,
+  source: "toc-generated-chapter-links",
+  hrefBuilder: "buildChapterReaderHref",
+} as const;
+
+// Reader pages are part of the existing site shell, not standalone documents.
+// They must keep the same locale-aware layout and shared controls used by book-home pages.
+export const READER_SHELL_RULES = {
+  preserveSharedShell: true,
+  preserveLocaleFromRoute: true,
+  preserveHeaderControls: ["language-switcher", "audience-switcher"] as const,
+} as const;
+
+// The reader sidebar is local navigation for the current chapter only.
+// Book-wide navigation, glossary behavior, and richer reader tools belong outside this core reader contract.
+export const READER_SIDEBAR_SCOPE = {
+  book: MVP_BOOK_ID,
+  source: "current-chapter-headings",
+  includeOnlyCurrentChapter: true,
+  allowBookWideSectionNavigation: false,
+  allowCrossChapterSectionNavigation: false,
+} as const;
+
+// The reader owns stable heading targets and basic hash navigation.
+// The visual polish of anchor links can evolve later, but IDs must stay predictable.
+export const READER_ANCHOR_RULES = {
+  source: "current-chapter-headings",
+  idBehavior: "stable-slug",
+  supportsSamePageHashLinks: true,
+  supportsDirectLoadHashLinks: true,
+} as const;
+
+export const READER_CORE_SCOPE = [
+  "chapter-reader-route",
+  "content-driven-static-paths",
+  "current-chapter-entry-loading",
+  "plain-mdx-body-rendering",
+  "shared-shell-preservation",
+  "chapter-level-orientation",
+  "current-chapter-heading-extraction",
+  "current-chapter-sidebar",
+  "reader-previous-next-navigation",
+  "stable-heading-anchors",
+  "working-section-deep-links",
+  "minimal-reader-empty-states",
+] as const;
+
+export const READER_DEFERRED_SCOPE = [
+  "figures-and-captions",
+  "styled-tables",
+  "columns",
+  "callouts",
+  "expanded-audience-conditional-block-rendering",
+  "glossary-hover-cards",
+  "localization-consolidation-or-fallback-logic",
+  "reader-visual-polish",
+] as const;


### PR DESCRIPTION
## Summary

Defines the durable reader conventions used by the chapter-reading experience.

This gives future reader work a clear route contract, shell integration rule, current-chapter navigation boundary, and scope boundary before the dynamic reader route is implemented.

## Changes

- Adds `reader-conventions.ts`
- Documents the canonical reader route contract already promised by the Table of Contents
- Defines shell preservation rules for reader pages
- Defines current-chapter-only sidebar scope
- Defines stable heading anchor expectations
- Documents richer reader capabilities that are outside the core reader contract

## Scope boundaries

This PR intentionally does not implement:

- dynamic chapter reader routes
- static path generation for chapter pages
- chapter entry loading
- MDX body rendering
- reader UI components
- current-chapter sidebar rendering
- previous/next chapter navigation
- heading anchor generation
- deep-link behavior

## Verification

- [x] `npm run check`

Closes #65