### PR TITLE
feat(reader): generate paths from chapters

### DIFF
--- a/src/pages/[lang]/book/[...slug].astro
+++ b/src/pages/[lang]/book/[...slug].astro
@@ -1,23 +1,18 @@
 ---
 import BaseLayout from "../../../layouts/BaseLayout.astro";
 import { getLocaleOrDefault, type Locale } from "../../../config/site";
+import { listChapterEntries } from "../../../lib/content/chapters";
 import { READER_ROUTE } from "../../../lib/content/reader-conventions";
 
-export function getStaticPaths() {
-  return [
-    {
-      params: {
-        lang: "en",
-        slug: "test/test-1",
-      },
+export async function getStaticPaths() {
+  const chapterEntries = await listChapterEntries();
+
+  return chapterEntries.map((entry) => ({
+    params: {
+      lang: entry.data.lang,
+      slug: entry.data.slug,
     },
-    {
-      params: {
-        lang: "pt-BR",
-        slug: "teste/teste-1",
-      },
-    },
-  ];
+  }));
 }
 
 const langParam = Astro.params.lang;


### PR DESCRIPTION
## Summary

Generates chapter reader static paths from chapter content metadata.

This removes the temporary hand-maintained route list and makes the reader scaffold follow the chapter collection as the source of truth.

## Changes

- Imports `listChapterEntries` into the dynamic reader route
- Replaces manually registered scaffold paths with content-driven static path generation
- Generates `lang` and `slug` params from chapter frontmatter
- Preserves the existing temporary reader scaffold UI
- Keeps nested chapter slugs working through the catch-all route

## Scope boundaries

This PR intentionally does not implement:

- current chapter entry loading
- missing-entry behavior
- MDX body rendering
- shared header controls inside the reader
- reader orientation UI
- current-chapter sidebar rendering
- previous/next chapter navigation
- heading anchor generation
- deep-link behavior

## Verification

- [x] `npm run check`
- [x] Manually checked `/en/book/test/test-1/`
- [x] Manually checked `/en/book/test/test-2/`
- [x] Manually checked `/pt-BR/book/teste/teste-1/`
- [x] Confirmed reader pages are generated from chapter metadata instead of a hand-maintained path list
- [x] Confirmed nested chapter slugs still render correctly

Closes #67