### PR TITLE
feat(reader): render chapter mdx

### DIFF
--- a/src/pages/[lang]/book/[...slug].astro
+++ b/src/pages/[lang]/book/[...slug].astro
@@ -1,4 +1,5 @@
 ---
+import { render } from "astro:content";
 import BaseLayout from "../../../layouts/BaseLayout.astro";
 import { getLocaleOrDefault, type Locale } from "../../../config/site";
 import { MVP_BOOK_ID } from "../../../lib/content/conventions";
@@ -41,6 +42,9 @@ const resolvedChapter = chapterEntry
     }
   : undefined;
 
+const renderedChapter = chapterEntry ? await render(chapterEntry) : undefined;
+const ChapterContent = renderedChapter?.Content;
+
 const copy = {
   en: {
     title: "Chapter Reader",
@@ -57,6 +61,7 @@ const copy = {
     missingTitle: "Chapter entry not found",
     missingBody:
       "The route exists, but the chapter entry could not be resolved from the current language and slug.",
+    contentLabel: "Chapter content",
   },
   "pt-BR": {
     title: "Leitor de Capítulo",
@@ -73,6 +78,7 @@ const copy = {
     missingTitle: "Entrada de capítulo não encontrada",
     missingBody:
       "A rota existe, mas a entrada do capítulo não pôde ser resolvida a partir do idioma e do slug atuais.",
+    contentLabel: "Conteúdo do capítulo",
   },
 } as const satisfies Record<
   Locale,
@@ -90,6 +96,7 @@ const copy = {
     audienceLabel: string;
     missingTitle: string;
     missingBody: string;
+    contentLabel: string;
   }
 >;
 
@@ -157,6 +164,17 @@ const pageDescription = resolvedChapter?.summary ?? pageCopy.description;
         )
       }
     </dl>
+
+    {
+      ChapterContent && (
+        <article
+          class="reader-route-scaffold__content"
+          aria-label={pageCopy.contentLabel}
+        >
+          <ChapterContent />
+        </article>
+      )
+    }
   </section>
 </BaseLayout>
 
@@ -206,5 +224,32 @@ const pageDescription = resolvedChapter?.summary ?? pageCopy.description;
 
   .reader-route-scaffold__meta dd {
     margin: 0;
+  }
+
+  .reader-route-scaffold__content {
+    display: grid;
+    gap: var(--space-4);
+    max-width: var(--reading-measure);
+    margin-top: var(--space-4);
+    padding-top: var(--space-5);
+    border-top: 1px solid var(--border-color);
+  }
+
+  .reader-route-scaffold__content :global(*) {
+    margin-bottom: 0;
+  }
+
+  .reader-route-scaffold__content :global(* + *) {
+    margin-top: var(--space-4);
+  }
+
+  .reader-route-scaffold__content :global(h1),
+  .reader-route-scaffold__content :global(h2),
+  .reader-route-scaffold__content :global(h3) {
+    max-width: var(--reading-measure);
+  }
+
+  .reader-route-scaffold__content :global(p) {
+    max-width: var(--reading-measure);
   }
 </style>


### PR DESCRIPTION
## Summary

Renders the resolved chapter body through the MDX pipeline.

This turns the reader scaffold into the first real chapter-reading page by rendering the current chapter content after the route and metadata resolution steps.

## Changes

- Imports `render` from `astro:content`
- Renders the resolved chapter entry through Astro’s MDX pipeline
- Adds the rendered chapter body below the temporary reader metadata scaffold
- Adds a localized content label for the rendered chapter body
- Adds minimal reader-content spacing without introducing rich content block styling

## Scope boundaries

This PR intentionally does not implement:

- shared header controls inside the reader
- reader orientation UI
- current-chapter sidebar rendering
- previous/next chapter navigation
- heading metadata extraction
- stable heading anchor generation
- deep-link behavior
- rich reader content blocks such as callouts, figures, captions, columns, or styled tables

## Verification

- [x] `npm run check`
- [x] Manually checked `/en/book/test/test-1/`
- [x] Manually checked `/en/book/test/test-2/`
- [x] Manually checked `/pt-BR/book/teste/teste-1/`
- [x] Confirmed the resolved chapter body renders through MDX
- [x] Confirmed PT-BR renders localized chapter body content

Closes #69