### PR TITLE
Complete Phase 5 chapter reader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,12 +28,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Book home route at `/{lang}/book/`.
 - Content-backed Table of Contents rendering.
 - Metadata-driven TOC ordering and grouping.
-- Future chapter-reader link generation from chapter slugs.
+- Chapter-reader link generation from chapter slugs.
 - Empty states and missing-data safeguards for sparse book content.
 - Book-home orientation cues and TOC overview metadata.
 - Basic responsive behavior for the Table of Contents layout.
+- Generated chapter reader route at `/{lang}/book/{slug}/`.
+- Static chapter reader paths generated from content metadata.
+- Chapter MDX rendering inside the shared shell.
+- Chapter-level orientation, return-to-TOC navigation, and reader metadata.
+- Current-chapter sidebar navigation generated from chapter headings.
+- Previous and next chapter links computed from content metadata.
+- Stable heading anchors and working section deep links.
+- Responsive fallback behavior for chapter-local navigation.
+- Sparse-heading safeguards for chapters with minimal structure.
 
 ### Changed
 
-- Updated the project status to reflect completion of Phase 4 — Book home / Table of Contents.
-- Updated the next implementation milestone to Phase 5 — Chapter reader.
+- Updated the project status to reflect completion of Phase 5 — Chapter reader.
+- Updated the next implementation milestone to Phase 6 — Rich content features.
+- Aligned repository documentation with the implemented reader scope and deferred Phase 6/7/8 boundaries.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,9 +2,9 @@
 
 ## Purpose
 
-This document explains how to contribute to the repository in its current Phase 1 state.
+This document explains how to contribute to the repository in its current state.
 
-The project is still building its open-source foundation, so the contribution process is intentionally simple and explicit.
+The project is still early and intentionally incremental, so the contribution process is simple and explicit.
 
 ## Before you contribute
 
@@ -17,8 +17,8 @@ The project is still building its open-source foundation, so the contribution pr
 
 Requirements:
 
-- a Node.js version supported by the current Astro release used in this repository
-- `npm`
+- Node.js `>=22.13.0 <23`
+- npm `>=11.7.0`
 
 Install dependencies:
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Return of the Night is an open-source web platform for reading RPG rulebooks, setting books, campaign books, and compendiums through a content-first digital-book experience.
 
-The repository has completed **Phase 4 — Book home / Table of Contents**. The current codebase is a plain Astro application with a shared site shell, locale-prefixed entry routes, typed content collections, initial chapter and glossary content, metadata utilities for chapter ordering and glossary lookup, and a content-backed book home page with an automatically generated Table of Contents. The next approved implementation step is **Phase 5 — Chapter reader**.
+The repository has completed **Phase 5 — Chapter reader**. The current codebase is a plain Astro application with a shared site shell, locale-prefixed entry routes, typed content collections, initial chapter and glossary content, metadata utilities for chapter ordering and glossary lookup, a content-backed book home page with an automatically generated Table of Contents, and generated chapter reader pages with MDX rendering, current-chapter navigation, previous/next links, heading anchors, and section deep links. The next approved implementation step is **Phase 6 — Rich content features**.
 
 ## Current status
 
@@ -18,7 +18,9 @@ The repository has completed **Phase 4 — Book home / Table of Contents**. The 
 - The repository includes seeded English content plus localized PT-BR mirrors that demonstrate shared logical IDs across languages.
 - Metadata utilities now support chapter listing by language and book, stable reading order, adjacent chapter resolution, glossary listing by language, and glossary lookup by logical ID.
 - The route `/{lang}/book/` renders the current book home and Table of Contents from real content metadata.
-- The Table of Contents supports metadata-driven ordering, book-config grouping, fallback grouping for sparse localized content, future chapter-reader links, empty states, orientation cues, and basic responsive behavior.
+- The Table of Contents supports metadata-driven ordering, book-config grouping, fallback grouping for sparse localized content, chapter-reader links, empty states, orientation cues, and basic responsive behavior.
+- The route `/{lang}/book/{slug}/` renders generated chapter reader pages from content entries.
+- Chapter reader pages support plain MDX content, current-chapter sidebar navigation, previous/next chapter navigation, stable heading anchors, working section links, sparse-heading safeguards, and responsive fallback behavior.
 - **Starlight is intentionally deferred** at this stage.
 - The repository language is **English-first** for code and contributor-facing artifacts.
 
@@ -31,8 +33,11 @@ The repository has completed **Phase 4 — Book home / Table of Contents**. The 
 - `/pt-BR/shell/`
 - `/en/book/`
 - `/pt-BR/book/`
+- `/en/book/test/test-1/`
+- `/en/book/test/test-2/`
+- `/pt-BR/book/teste/teste-1/`
 
-## Content and Table of Contents status
+## Content and Reader Status
 
 - `src/content/chapters/en/` contains seeded chapter content for the MVP book.
 - `src/content/chapters/pt-BR/` contains a localized mirror that demonstrates the shared logical `id` rule.
@@ -41,11 +46,13 @@ The repository has completed **Phase 4 — Book home / Table of Contents**. The 
 - `src/content/config/` contains the first book-level config entry for the MVP book.
 - `src/lib/content/chapters.ts` provides chapter listing, ordering, and adjacent-entry utilities.
 - `src/lib/content/toc.ts` provides metadata-driven grouping for the Table of Contents.
-- `src/lib/content/chapter-routes.ts` provides future chapter-reader href generation from chapter slugs.
+- `src/lib/content/chapter-routes.ts` provides chapter-reader href generation from chapter slugs.
 - `src/lib/glossary/entries.ts` provides glossary listing and lookup utilities.
 - `src/components/reader/BookTableOfContents.astro` renders the current book home and Table of Contents experience.
+- `src/components/reader/ReaderHeading2.astro` and `src/components/reader/ReaderHeading3.astro` render linkable reader headings for MDX content.
+- `src/pages/[lang]/book/[...slug].astro` renders generated chapter reader pages.
 
-The app now renders the real book home and Table of Contents. It still does not render chapter reader pages, sidebar navigation, heading anchors, previous/next chapter navigation, or interactive glossary UI. Those remain part of later phases.
+The app now renders the real book home, Table of Contents, and chapter reader. Interactive glossary UI, rich content blocks, full localization parity, and visual refinement remain part of later phases.
 
 ## Source of truth
 
@@ -55,6 +62,7 @@ The documents in [`docs/`](docs/) are the source of truth for this repository.
 - [`docs/return-of-the-night-source-of-truth-v0.2.md`](docs/return-of-the-night-source-of-truth-v0.2.md): setting canon and project background for Return of the Night.
 - [`docs/adr/0001-bootstrap-strategy.md`](docs/adr/0001-bootstrap-strategy.md): accepted Phase 1 decision to use plain Astro and defer Starlight.
 - [`docs/architecture.md`](docs/architecture.md): repository architecture direction, system layers, and planned implementation order.
+- [`docs/phase-5.md`](docs/phase-5.md): implemented Phase 5 reader milestone scope, boundary, and exit criteria.
 - [`docs/assets-policy.md`](docs/assets-policy.md): repository policy for asset provenance and licensing.
 - [`docs/assets-register.md`](docs/assets-register.md): current register for asset source, author, license, and usage notes.
 - [`docs/shell-reading-and-visual-guidelines.md`](docs/shell-reading-and-visual-guidelines.md): the current visual and reading-direction guide for the shell.
@@ -81,7 +89,7 @@ npm install
 npm run dev
 ```
 
-The development server starts the current application shell and content-backed book home. Useful routes to verify locally:
+The development server starts the current application shell, content-backed book home, and generated reader pages. Useful routes to verify locally:
 
 - `/`
 - `/en/`
@@ -90,6 +98,10 @@ The development server starts the current application shell and content-backed b
 - `/pt-BR/shell/`
 - `/en/book/`
 - `/pt-BR/book/`
+- `/en/book/test/test-1/`
+- `/en/book/test/test-1/#test-section`
+- `/en/book/test/test-2/`
+- `/pt-BR/book/teste/teste-1/`
 
 ## Available scripts
 
@@ -106,15 +118,14 @@ The development server starts the current application shell and content-backed b
 
 ## Current boundaries
 
-The current implementation intentionally stops at the end of Phase 4. The repository does **not** yet include:
+The current implementation intentionally stops at the end of Phase 5. The repository does **not** yet include:
 
-- generated chapter routes or reader page UI
-- heading anchors or chapter-local sidebar navigation
-- previous/next chapter navigation in the reader
+- Phase 6 rich content blocks such as figures with captions, styled tables, columns, and callouts
+- expanded audience-conditional block rendering
 - glossary hover cards or glossary-linked reader interactions
 - full translation parity across localized content
-- localization-aware reader behavior beyond the current shared shell and book home routes
-- polished reader layouts beyond the current landing page, shell, and book home
+- localization fallback behavior or equivalent cross-locale reader routes
+- broader UX polish beyond the current functional reader, shell, landing page, and book home
 
 ## Project direction
 
@@ -127,7 +138,7 @@ The long-term direction is to build a maintainable RPG digital-book platform wit
 - localization support, starting with English and PT-BR
 - a writing workflow that stays close to Markdown and MDX
 
-The repository has finished its foundation, base shell, content engine, and book home / Table of Contents phases. The next implementation milestone is to turn chapter content into a real reader experience.
+The repository has finished its foundation, base shell, content engine, book home / Table of Contents, and chapter reader phases. The next implementation milestone is to add rich content features while preserving the Markdown/MDX-first authoring model.
 
 ## Licensing
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,9 +6,9 @@ The source of truth for detailed scope, architecture direction, and implementati
 
 ## Current phase
 
-The repository has completed **Phase 4 — Book home / Table of Contents**.
+The repository has completed **Phase 5 — Chapter reader**.
 
-The next implementation milestone is **Phase 5 — Chapter reader**.
+The next implementation milestone is **Phase 6 — Rich content features**.
 
 ## Planned phases
 
@@ -55,7 +55,7 @@ Generate the book home page from real content:
 - book-home orientation cues
 - basic responsive behavior for the TOC layout
 
-### Phase 5 — Chapter reader ← Next
+### Phase 5 — Chapter reader ✅
 
 Turn chapters into a real reading experience:
 
@@ -65,7 +65,7 @@ Turn chapters into a real reading experience:
 - previous and next navigation
 - deep links and heading anchors
 
-### Phase 6 — Rich content features
+### Phase 6 — Rich content features ← Next
 
 Add expressive content blocks and reader features:
 

--- a/docs/adr/0001-bootstrap-strategy.md
+++ b/docs/adr/0001-bootstrap-strategy.md
@@ -10,7 +10,7 @@ Accepted
 
 The main platform blueprint defines the project as an open-source RPG digital-book platform built with strong repository hygiene, architectural decision tracking, progressive complexity, and a learning-oriented approach. It favors understanding and maintainability over immediate convenience.
 
-At the same time, the current Return of the Night source-of-truth describes the project in its present form as a private, player-facing campaign wiki and rules reference, with an Astro + Starlight platform plan.
+At the time this ADR was written, the Return of the Night source-of-truth described the project in its present form as a private, player-facing campaign wiki and rules reference, with an Astro + Starlight platform plan.
 
 Because of that, there is a real early-stage tension between two valid directions:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10,7 +10,7 @@ For detailed product scope and long-term roadmap, see [`docs/open_rulebook_platf
 
 ## Current architectural direction
 
-The repository is currently structured around a **plain Astro** foundation with the Phase 2 shell, Phase 3 content engine, and Phase 4 book home / Table of Contents implemented.
+The repository is currently structured around a **plain Astro** foundation with the Phase 2 shell, Phase 3 content engine, Phase 4 book home / Table of Contents, and Phase 5 chapter reader implemented.
 
 That choice is intentional for Phase 1. The current architecture prioritizes:
 
@@ -19,7 +19,7 @@ That choice is intentional for Phase 1. The current architecture prioritizes:
 - progressive complexity over premature abstraction
 - open-source readiness over fast visual polish
 
-At the moment, the project is a static Astro application with repository-quality tooling, locale-prefixed shell routes, Astro content collections, typed schemas, initial content seeds, metadata utilities for chapters and glossary entries, and a content-backed book home route that renders an automatically generated Table of Contents.
+At the moment, the project is a static Astro application with repository-quality tooling, locale-prefixed shell routes, Astro content collections, typed schemas, initial content seeds, metadata utilities for chapters and glossary entries, a content-backed book home route that renders an automatically generated Table of Contents, and generated chapter reader pages that render MDX content.
 
 ## Core system layers
 
@@ -35,11 +35,11 @@ This layer currently provides:
 - the shared shell
 - language and audience controls
 - the book home and Table of Contents
+- the chapter reader
+- chapter-local navigation controls
 
 In later phases, this layer is expected to provide:
 
-- the chapter reader
-- chapter-local navigation controls
 - glossary interactions
 - richer reader layouts
 
@@ -67,7 +67,7 @@ Expected responsibilities include:
 - localization utilities
 - reader-specific navigation logic
 
-In the current repository, this layer includes implemented utilities for content loading, chapter ordering, TOC grouping, future chapter-reader link generation, glossary listing, glossary lookup, locale routing, and audience preference handling. Later-phase reader-specific behavior still remains deferred.
+In the current repository, this layer includes implemented utilities for content loading, chapter ordering, adjacent chapter resolution, TOC grouping, chapter-reader link generation, glossary listing, glossary lookup, locale routing, and audience preference handling. Later-phase rich content, glossary interaction, and localization consolidation behavior still remains deferred.
 
 ### 4. Repository and governance layer
 
@@ -93,7 +93,7 @@ Important directories and files:
 - `public/images/`: public-facing image asset location
 - `src/pages/`: Astro route entry points
 - `src/pages/[lang]/`: language-prefixed route space, including landing, shell, and book home routes
-- `src/components/`: UI and reader component area, including the current `BookTableOfContents` component
+- `src/components/`: UI and reader component area, including the current `BookTableOfContents` and reader heading components
 - `src/content/`: implemented content collections for chapters, glossary, and book config
 - `src/layouts/`: future shared layout area
 - `src/lib/`: reusable domain and utility logic, including content, TOC, glossary, locale-routing, and audience helpers
@@ -104,15 +104,16 @@ Current implementation status:
 
 - `src/pages/index.astro`, `src/pages/[lang]/index.astro`, and `src/pages/[lang]/shell/index.astro` provide the current landing and shell entry routes
 - `src/pages/[lang]/book/index.astro` provides the current book home route
+- `src/pages/[lang]/book/[...slug].astro` provides generated chapter reader routes
 - Astro content collections are registered in `src/content.config.ts`
 - typed schemas exist for `chapters`, `glossary`, and `book-config`
 - seed content exists for English chapters, English glossary entries, an English book config entry, and mirrored PT-BR examples for logical identity validation
 - chapter metadata utilities support listing by language/book, stable ordering, and previous/next resolution
 - TOC utilities support metadata-driven grouping, configured groups, and fallback ungrouped entries
-- chapter route utilities generate future reader links from content slugs
+- chapter route utilities generate reader links from content slugs
 - glossary metadata utilities support listing by language and lookup by logical `id`
 - the book home renders a content-backed Table of Contents with empty states, orientation cues, and basic responsive behavior
-- there is still no implemented reader route, MDX reader rendering, chapter sidebar, heading anchors, glossary interaction UI, or full localization layer
+- the chapter reader renders MDX content, chapter-level orientation, current-chapter sidebar navigation, previous/next links, stable heading anchors, and section deep links
 
 ## Current boundaries
 
@@ -123,20 +124,19 @@ The current implementation includes:
 - audience preference persistence and shell controls
 - typed Astro content collections for chapters, glossary, and book config
 - initial content seeds in English plus mirrored PT-BR examples for shared logical IDs
-- metadata utilities for chapter listing, ordering, adjacent navigation, TOC grouping, future reader link generation, and glossary lookup
+- metadata utilities for chapter listing, ordering, adjacent navigation, TOC grouping, reader link generation, and glossary lookup
 - a content-backed book home / Table of Contents with empty states, orientation cues, and basic responsive behavior
+- generated chapter reader pages with plain MDX rendering, current-chapter sidebar navigation, previous/next chapter navigation, stable heading anchors, working section links, responsive fallback behavior, and sparse-heading safeguards
 
 The current implementation does **not** yet include:
 
-- generated chapter reader routes
-- MDX reader page rendering
-- chapter-local sidebar UI or heading anchors
-- previous/next chapter navigation in the reader
+- Phase 6 rich content blocks such as figure/caption systems, styled tables, columns, and callouts
+- expanded audience-conditional block rendering
 - glossary hover cards or reader-side glossary interactions
 - full translation parity or complete localization behavior
 - authentication, authorization, or backend infrastructure
 
-This means the repository now reflects the first real content-driven presentation layer of the system, while the chapter reader and richer interaction features remain planned rather than implemented.
+This means the repository now reflects the first complete content-driven reader layer of the system, while richer content blocks, glossary interactions, and localization consolidation remain planned rather than implemented.
 
 ## Planned evolution
 
@@ -146,8 +146,12 @@ The intended implementation order remains incremental:
 2. base site structure and route shell — completed
 3. content engine and schemas — completed
 4. book home and Table of Contents generation — completed
-5. chapter reader — next
-6. rich content features, glossary behavior, and localization refinement — planned
+5. chapter reader — completed
+6. rich content features — next
+7. interactive glossary — planned
+8. real localization — planned
+9. UX and layout refinement — planned
+10. contribution docs and hardening — planned
 
 The architecture should continue to follow these principles as the project grows:
 

--- a/docs/assets-policy.md
+++ b/docs/assets-policy.md
@@ -1,6 +1,6 @@
 # Asset Policy
 
-This document defines the minimum asset provenance and licensing policy for the repository during Phase 1.
+This document defines the minimum asset provenance and licensing policy for the repository.
 
 ## Purpose
 
@@ -57,4 +57,4 @@ Every repository-tracked asset must have an entry in [`docs/assets-register.md`]
 
 ## Current register location
 
-The authoritative provenance register for Phase 1 is [`docs/assets-register.md`](./assets-register.md).
+The authoritative provenance register is [`docs/assets-register.md`](./assets-register.md).

--- a/docs/open_rulebook_platform_blueprint.md
+++ b/docs/open_rulebook_platform_blueprint.md
@@ -891,7 +891,7 @@ Generate the book home page automatically from the content model.
 - the book page shows the real chapters from content
 - the order matches the metadata
 - chapter grouping works from book configuration and safe fallback behavior
-- links point to the correct future chapter reader destinations
+- links point to the correct chapter reader destinations
 - the page handles sparse or missing content safely
 - the page provides basic orientation cues and mobile-readable TOC behavior
 
@@ -1076,14 +1076,13 @@ Prepare the project to grow without turning into chaos.
 
 ## 23. Recommended implementation order now
 
-The project has completed the first four implementation phases. The current recommended sequence from this point is:
+The project has completed the first five implementation phases. The current recommended sequence from this point is:
 
-1. Phase 5 — Chapter reader
-2. Phase 6 — Rich content features
-3. Phase 7 — Interactive glossary
-4. Phase 8 — Real localization
-5. Phase 9 — UX/layout refinement
-6. Phase 10 — Contribution docs and hardening
+1. Phase 6 — Rich content features
+2. Phase 7 — Interactive glossary
+3. Phase 8 — Real localization
+4. Phase 9 — UX/layout refinement
+5. Phase 10 — Contribution docs and hardening
 
 ---
 
@@ -1115,17 +1114,17 @@ For each step:
 
 The next concrete milestone is:
 
-### **Phase 5 — Chapter reader**
+### **Phase 6 — Rich content features**
 
 That means the next practical tasks should be, in order:
 
-1. create the dynamic chapter reader route
-2. generate static paths from chapter content metadata
-3. render MDX chapter content for the active language
-4. preserve the existing locale and reading-mode shell controls
-5. add chapter-level orientation around the reader page
-6. compute previous and next chapter navigation from metadata
-7. keep sidebar, heading anchors, and deeper reader polish scoped carefully to Phase 5 sub-steps
+1. define author-facing conventions for rich content blocks
+2. add image and caption support
+3. add styled table support
+4. add side-by-side layout support
+5. add callout support
+6. keep audience-conditional block rendering scoped to the Phase 6 boundary
+7. avoid glossary hover cards, localization fallback logic, and broad visual polish until their later phases
 
 ---
 
@@ -1154,7 +1153,8 @@ Core decisions must not change silently.
 - base site structure completed
 - content engine completed
 - book home / Table of Contents completed
-- ready to start Phase 5 — Chapter reader
+- chapter reader completed
+- ready to start Phase 6 — Rich content features
 
 ---
 
@@ -1162,6 +1162,6 @@ Core decisions must not change silently.
 
 We are building **Return of the Night**, an open-source RPG digital-book platform with MDX-based content, rich navigation, interactive glossary behavior, player/GM reading modes, and support for English and PT-BR.
 
-The implementation strategy is incremental: the repository foundation, site shell, content engine, and book home / Table of Contents are now in place. The next step is to turn chapter content into a real reader experience before moving into rich authoring features, glossary interactions, localization consolidation, and visual refinement.
+The implementation strategy is incremental: the repository foundation, site shell, content engine, book home / Table of Contents, and chapter reader are now in place. The next step is to add rich authoring features before moving into glossary interactions, localization consolidation, and visual refinement.
 
 The priorities are understanding, clarity, maintainability, and real open-source readiness — not speed or premature complexity.

--- a/docs/phase-5.md
+++ b/docs/phase-5.md
@@ -20,6 +20,12 @@ Turn content pages into a real reading experience.
 - prev/next works
 - links to specific sections work
 
+## Implementation status
+
+Phase 5 is implemented in the reader route under `src/pages/[lang]/book/[...slug].astro`.
+
+The implementation keeps the Phase 5 boundary intact: it renders plain MDX chapters, derives local navigation from the current chapter headings, adds previous/next chapter links from content metadata, exposes stable section anchors, supports section deep links, and includes responsive and sparse-heading fallbacks. It does not add Phase 6 rich content blocks, Phase 7 glossary hover cards, or Phase 8 localization fallback logic.
+
 ## Phase boundary
 
 This milestone includes the **reader route and chapter-reading experience only**. It does **not** include Phase 6 rich content blocks like figures/captions, styled tables, columns, callouts, or audience-conditional block rendering beyond whatever already exists in plain MDX. It also does **not** include Phase 7 glossary hover cards or Phase 8 localization consolidation work.
@@ -151,7 +157,7 @@ This milestone includes the **reader route and chapter-reading experience only**
 
 `P5-60 → P5-61 → P5-62 → P5-63 → P5-64 → P5-65 → P5-66 → P5-67 → P5-68 → P5-69 → P5-70 → P5-71 → P5-72 → P5-73 → P5-74 → P5-75`
 
-This order follows the current roadmap and the live repo state: first fulfill the existing future reader link contract, then load and render real chapter content, then add orientation and sidebar behavior, then wire previous/next and deep links, and only then close the milestone.
+This order follows the roadmap and the reader link contract established by the Table of Contents: first match the generated chapter URLs, then load and render real chapter content, then add orientation and sidebar behavior, then wire previous/next and deep links, and only then close the milestone.
 
 ---
 

--- a/docs/return-of-the-night-source-of-truth-v0.2.md
+++ b/docs/return-of-the-night-source-of-truth-v0.2.md
@@ -13,7 +13,7 @@
 **Portuguese title:** A Volta da Noite
 
 **Current format:** a private, player-facing campaign wiki and rules reference for our table  
-**Platform plan:** Astro + Starlight  
+**Platform plan:** plain Astro digital-book/wiki experience; Starlight is deferred by ADR 0001  
 **System base:** Cities Without Number (CWN)
 
 This is **not** currently planned as a public commercial RPG product. It is a **private campaign setting + table hack + player resource** built for our own use, using the core engine of CWN and adapting it to an original dystopian cyberpunk world.
@@ -1038,7 +1038,7 @@ If campaigns move beyond the Arcologies, the outside should support a distinct m
 
 ## 25. Wiki direction
 
-The project’s player-facing presentation should take the form of a private **Astro/Starlight wiki**.
+The project’s player-facing presentation should take the form of a private **Astro-based digital-book/wiki experience**. Starlight remains a deferred option rather than the current implementation plan.
 
 ### 25.1 Why this format
 

--- a/docs/shell-reading-and-visual-guidelines.md
+++ b/docs/shell-reading-and-visual-guidelines.md
@@ -1,8 +1,8 @@
-# Phase 2 Shell, Reading Experience, and Visual Direction Guidelines
+# Shell, Reading Experience, and Visual Direction Guidelines
 
 ## Purpose
 
-This document captures the current functional and visual direction for the **Return of the Night** site shell and future reading experience. It is intended to guide implementation decisions starting in **Phase 2** while preserving a clear boundary between what is being established now and what belongs to later phases.
+This document captures the current functional and visual direction for the **Return of the Night** site shell and reading experience. It is intended to guide implementation decisions as the product evolves while preserving a clear boundary between what exists now and what belongs to later phases.
 
 The goal is not to fully design the final product yet, but to define the **experience principles, interface expectations, visual identity, and early design constraints** that should shape the shell from this point onward.
 
@@ -70,7 +70,7 @@ The system should therefore be designed as a **reading platform**, not just as a
 
 ## Global shell
 
-The upper part of the site should eventually support:
+The upper part of the site supports or should remain compatible with:
 
 - site branding
 - a home/landing entry point
@@ -99,7 +99,7 @@ When the platform eventually supports multiple books or multiple major sources, 
 - site / source / book / chapter
 - or equivalent breadcrumb-like orientation
 
-This does not need to be fully implemented in Phase 2, but the shell should be compatible with this future direction.
+This does not need to be fully implemented while the project supports one book, but the shell should remain compatible with this future direction.
 
 ### Reader layout
 
@@ -126,7 +126,7 @@ This means the reader navigation should be **useful but dismissible**, not alway
 
 ### Table of Contents
 
-The Table of Contents should eventually be:
+The Table of Contents should be:
 
 - generated automatically from book structure and content metadata
 - procedural rather than hand-maintained
@@ -604,9 +604,9 @@ Spacing should support:
 
 ---
 
-## Practical Design Guidance for Phase 2 Shell
+## Practical Design Guidance for the Shell and Reader
 
-When implementing the shell in Phase 2, the design should already suggest:
+When evolving the shell and reader, the design should suggest:
 
 - a product, not a bare starter app
 - reading seriousness
@@ -635,4 +635,4 @@ The intended design direction for **Return of the Night** is:
 - immersive but still highly usable
 - flexible enough to support both simple reading pages and more expressive layouts later
 
-This document should guide shell-level decisions from Phase 2 onward so that the product grows in a coherent direction rather than feeling visually or structurally improvised.
+This document should guide shell- and reader-level decisions so that the product grows in a coherent direction rather than feeling visually or structurally improvised.

--- a/docs/writing-guide.md
+++ b/docs/writing-guide.md
@@ -2,11 +2,11 @@
 
 ## Purpose
 
-This document defines the minimum writing standards for the repository during Phase 1.
+This document defines the minimum writing standards for the repository.
 
-Its goal is to keep project artifacts understandable, consistent, and maintainable while the repository is still establishing its foundation.
+Its goal is to keep project artifacts understandable, consistent, and maintainable as the project grows through the roadmap.
 
-For product direction and long-term editorial goals, see [`docs/open_rulebook_platform_blueprint.md`](./open_rulebook_platform_blueprint.md). For current Phase 1 scope, see [`docs/phase-1.md`](./phase-1.md).
+For product direction and long-term editorial goals, see [`docs/open_rulebook_platform_blueprint.md`](./open_rulebook_platform_blueprint.md). For current implementation status, see [`ROADMAP.md`](../ROADMAP.md) and [`docs/architecture.md`](./architecture.md).
 
 ## Repository language policy
 
@@ -51,7 +51,7 @@ Use plain Markdown when:
 - no interactive behavior is needed
 - the content should stay easy to edit in any text editor
 
-MDX should only be introduced when it provides a clear benefit that plain Markdown cannot cover cleanly. In Phase 1, that benefit is expected to be rare.
+MDX should only be introduced when it provides a clear benefit that plain Markdown cannot cover cleanly. Chapter content can use MDX, but repository documentation should stay plain Markdown unless there is a deliberate reason otherwise.
 
 General expectations:
 
@@ -81,7 +81,7 @@ The documents in `docs/` are the source of truth for repository direction. If im
 
 ## Future editorial expansion
 
-This guide is intentionally minimal for Phase 1.
+This guide is intentionally minimal.
 
 Later phases may extend it with more detailed rules for:
 

--- a/src/components/reader/ReaderHeading2.astro
+++ b/src/components/reader/ReaderHeading2.astro
@@ -1,0 +1,63 @@
+---
+interface Props {
+  id?: string;
+  class?: string;
+}
+
+const { id, class: className, ...attrs } = Astro.props as Props;
+---
+
+<h2 {...attrs} id={id} class:list={["reader-heading", className]}>
+  <slot />
+  {
+    id && (
+      <a
+        class="reader-heading__anchor"
+        href={`#${id}`}
+        aria-label="Link to this section"
+      >
+        <span aria-hidden="true">#</span>
+      </a>
+    )
+  }
+</h2>
+
+<style>
+  .reader-heading {
+    scroll-margin-top: calc(5rem + var(--space-6));
+  }
+
+  .reader-heading__anchor {
+    margin-left: var(--space-2);
+    color: var(--muted-text-color);
+    font-family: var(--font-ui);
+    font-size: 0.85em;
+    font-weight: 700;
+    opacity: 0;
+    text-decoration: none;
+    transition:
+      color 160ms ease,
+      opacity 160ms ease;
+  }
+
+  .reader-heading:hover .reader-heading__anchor,
+  .reader-heading:focus-within .reader-heading__anchor {
+    opacity: 1;
+  }
+
+  .reader-heading__anchor:hover,
+  .reader-heading__anchor:focus-visible {
+    color: var(--accent-primary-strong);
+    opacity: 1;
+  }
+
+  @media (max-width: 40rem) {
+    .reader-heading {
+      scroll-margin-top: calc(8rem + var(--space-6));
+    }
+
+    .reader-heading__anchor {
+      opacity: 1;
+    }
+  }
+</style>

--- a/src/components/reader/ReaderHeading3.astro
+++ b/src/components/reader/ReaderHeading3.astro
@@ -1,0 +1,63 @@
+---
+interface Props {
+  id?: string;
+  class?: string;
+}
+
+const { id, class: className, ...attrs } = Astro.props as Props;
+---
+
+<h3 {...attrs} id={id} class:list={["reader-heading", className]}>
+  <slot />
+  {
+    id && (
+      <a
+        class="reader-heading__anchor"
+        href={`#${id}`}
+        aria-label="Link to this section"
+      >
+        <span aria-hidden="true">#</span>
+      </a>
+    )
+  }
+</h3>
+
+<style>
+  .reader-heading {
+    scroll-margin-top: calc(5rem + var(--space-6));
+  }
+
+  .reader-heading__anchor {
+    margin-left: var(--space-2);
+    color: var(--muted-text-color);
+    font-family: var(--font-ui);
+    font-size: 0.85em;
+    font-weight: 700;
+    opacity: 0;
+    text-decoration: none;
+    transition:
+      color 160ms ease,
+      opacity 160ms ease;
+  }
+
+  .reader-heading:hover .reader-heading__anchor,
+  .reader-heading:focus-within .reader-heading__anchor {
+    opacity: 1;
+  }
+
+  .reader-heading__anchor:hover,
+  .reader-heading__anchor:focus-visible {
+    color: var(--accent-primary-strong);
+    opacity: 1;
+  }
+
+  @media (max-width: 40rem) {
+    .reader-heading {
+      scroll-margin-top: calc(8rem + var(--space-6));
+    }
+
+    .reader-heading__anchor {
+      opacity: 1;
+    }
+  }
+</style>

--- a/src/pages/[lang]/book/[...slug].astro
+++ b/src/pages/[lang]/book/[...slug].astro
@@ -1,12 +1,17 @@
 ---
 import BaseLayout from "../../../layouts/BaseLayout.astro";
+import ReaderHeading2 from "../../../components/reader/ReaderHeading2.astro";
+import ReaderHeading3 from "../../../components/reader/ReaderHeading3.astro";
 import ShellHeaderControls from "../../../components/ui/ShellHeaderControls.astro";
 import { render } from "astro:content";
+import { getBookConfigEntryByLanguageAndBook } from "../../../lib/content/book-config";
+import { buildChapterReaderHref } from "../../../lib/content/chapter-routes";
 import { MVP_BOOK_ID } from "../../../lib/content/conventions";
-import { READER_ROUTE } from "../../../lib/content/reader-conventions";
 import {
+  getAdjacentChapterEntriesByLanguageAndBook,
   getChapterEntryByLanguageBookAndSlug,
   listChapterEntries,
+  type ChapterEntry,
 } from "../../../lib/content/chapters";
 import {
   AUDIENCES,
@@ -29,23 +34,39 @@ interface ReaderSidebarItem {
   children: ReaderSidebarItem[];
 }
 
+interface ReaderAdjacentLink {
+  href: string;
+  chapterNumber: number;
+  chapterTitle: string;
+  pageTitle: string;
+}
+
 function normalizeReaderHeadings(
   headings: ReaderHeading[] | undefined,
 ): ReaderHeading[] {
-  return (headings ?? [])
-    .filter((heading) => heading.depth >= 2 && heading.depth <= 3)
-    .map((heading) => ({
-      depth: heading.depth,
-      slug: heading.slug,
-      text: heading.text,
-    }));
+  return (headings ?? []).flatMap((heading) => {
+    const slug = heading.slug.trim();
+    const text = heading.text.trim();
+
+    if (heading.depth < 2 || heading.depth > 3 || !slug || !text) {
+      return [];
+    }
+
+    return [
+      {
+        depth: heading.depth,
+        slug,
+        text,
+      },
+    ];
+  });
 }
 
 function buildReaderSidebarItems(
   headings: ReaderHeading[],
 ): ReaderSidebarItem[] {
   const items: ReaderSidebarItem[] = [];
-  let currentParent: ReaderSidebarItem | undefined;
+  let currentLevelTwo: ReaderSidebarItem | undefined;
 
   for (const heading of headings) {
     const item: ReaderSidebarItem = {
@@ -58,20 +79,31 @@ function buildReaderSidebarItems(
 
     if (heading.depth === 2) {
       items.push(item);
-      currentParent = item;
+      currentLevelTwo = item;
       continue;
     }
 
-    if (heading.depth === 3 && currentParent) {
-      currentParent.children.push(item);
+    if (heading.depth === 3 && currentLevelTwo) {
+      currentLevelTwo.children.push(item);
       continue;
     }
 
     items.push(item);
-    currentParent = item;
   }
 
   return items;
+}
+
+function buildReaderAdjacentLink(
+  lang: Locale,
+  chapter: ChapterEntry,
+): ReaderAdjacentLink {
+  return {
+    href: buildChapterReaderHref(lang, chapter),
+    chapterNumber: chapter.data.chapterNumber,
+    chapterTitle: chapter.data.chapterTitle,
+    pageTitle: chapter.data.pageTitle,
+  };
 }
 
 export async function getStaticPaths() {
@@ -96,6 +128,21 @@ const chapterEntry = await getChapterEntryByLanguageBookAndSlug({
   book: MVP_BOOK_ID,
   slug,
 });
+
+const bookConfigEntry = await getBookConfigEntryByLanguageAndBook({
+  lang,
+  book: MVP_BOOK_ID,
+});
+
+const adjacentChapterEntries = chapterEntry
+  ? await getAdjacentChapterEntriesByLanguageAndBook(
+      {
+        lang,
+        book: MVP_BOOK_ID,
+      },
+      chapterEntry.data.id,
+    )
+  : undefined;
 
 const resolvedChapter = chapterEntry
   ? {
@@ -123,20 +170,27 @@ const audienceLabels = {
 
 const renderedChapter = chapterEntry ? await render(chapterEntry) : undefined;
 const ChapterContent = renderedChapter?.Content;
+const readerMdxComponents = {
+  h2: ReaderHeading2,
+  h3: ReaderHeading3,
+};
 const readerHeadings = normalizeReaderHeadings(renderedChapter?.headings);
 const readerSidebarItems = buildReaderSidebarItems(readerHeadings);
+const previousChapter = adjacentChapterEntries?.previous
+  ? buildReaderAdjacentLink(lang, adjacentChapterEntries.previous)
+  : undefined;
+const nextChapter = adjacentChapterEntries?.next
+  ? buildReaderAdjacentLink(lang, adjacentChapterEntries.next)
+  : undefined;
 
 const copy = {
   en: {
     title: "Chapter Reader",
-    description: "Temporary chapter reader route scaffold.",
-    eyebrow: "Reader route scaffold",
-    heading: "Chapter reader route",
-    body: "This temporary page confirms that the chapter reader route exists and matches the Table of Contents link contract.",
-    routeLabel: "Route pattern",
-    slugLabel: "Current slug",
-    resolvedChapterLabel: "Resolved chapter",
-    chapterTitleLabel: "Chapter title",
+    description: "Read a chapter from the Return of the Night core book.",
+    eyebrow: "Chapter reader",
+    heading: "Chapter reader",
+    body: "Choose a chapter from the Table of Contents to start reading.",
+    chapterMetadataLabel: "Chapter metadata",
     statusLabel: "Status",
     audienceLabel: "Audience",
     missingTitle: "Chapter entry not found",
@@ -151,18 +205,21 @@ const copy = {
     chapterLabel: "Chapter",
     backToTocLabel: "Back to Table of Contents",
     sidebarLabel: "On this page",
-    emptySidebarLabel: "This chapter does not have local sections yet.",
+    emptySidebarLabel:
+      "This chapter does not have local sections yet. Continue reading from the main content.",
+    chapterNavigationLabel: "Chapter navigation",
+    previousChapterLabel: "Previous Chapter",
+    nextChapterLabel: "Next Chapter",
+    previousChapterUnavailableLabel: "This is the first available chapter.",
+    nextChapterUnavailableLabel: "This is the last available chapter.",
   },
   "pt-BR": {
     title: "Leitor de Capítulo",
-    description: "Estrutura temporária da rota de leitura de capítulo.",
-    eyebrow: "Estrutura da rota de leitura",
-    heading: "Rota de leitura de capítulo",
-    body: "Esta página temporária confirma que a rota de leitura de capítulo existe e corresponde ao contrato de links do Sumário.",
-    routeLabel: "Padrão da rota",
-    slugLabel: "Slug atual",
-    resolvedChapterLabel: "Capítulo resolvido",
-    chapterTitleLabel: "Título do capítulo",
+    description: "Leia um capítulo do livro principal de Return of the Night.",
+    eyebrow: "Leitor de capítulo",
+    heading: "Leitor de capítulo",
+    body: "Escolha um capítulo pelo Sumário para começar a leitura.",
+    chapterMetadataLabel: "Metadados do capítulo",
     statusLabel: "Status",
     audienceLabel: "Público",
     missingTitle: "Entrada de capítulo não encontrada",
@@ -177,7 +234,13 @@ const copy = {
     chapterLabel: "Capítulo",
     backToTocLabel: "Voltar ao Sumário",
     sidebarLabel: "Nesta página",
-    emptySidebarLabel: "Este capítulo ainda não tem seções locais.",
+    emptySidebarLabel:
+      "Este capítulo ainda não tem seções locais. Continue a leitura pelo conteúdo principal.",
+    chapterNavigationLabel: "Navegação entre capítulos",
+    previousChapterLabel: "Capítulo Anterior",
+    nextChapterLabel: "Próximo Capítulo",
+    previousChapterUnavailableLabel: "Este é o primeiro capítulo disponível.",
+    nextChapterUnavailableLabel: "Este é o último capítulo disponível.",
   },
 } as const satisfies Record<
   Locale,
@@ -187,10 +250,7 @@ const copy = {
     eyebrow: string;
     heading: string;
     body: string;
-    routeLabel: string;
-    slugLabel: string;
-    resolvedChapterLabel: string;
-    chapterTitleLabel: string;
+    chapterMetadataLabel: string;
     statusLabel: string;
     audienceLabel: string;
     missingTitle: string;
@@ -205,10 +265,22 @@ const copy = {
     backToTocLabel: string;
     sidebarLabel: string;
     emptySidebarLabel: string;
+    chapterNavigationLabel: string;
+    previousChapterLabel: string;
+    nextChapterLabel: string;
+    previousChapterUnavailableLabel: string;
+    nextChapterUnavailableLabel: string;
   }
 >;
 
 const pageCopy = copy[lang];
+const tocLabel =
+  bookConfigEntry?.data.navigation.tableOfContents ?? pageCopy.tocLabel;
+const previousChapterLabel =
+  bookConfigEntry?.data.navigation.previousChapter ??
+  pageCopy.previousChapterLabel;
+const nextChapterLabel =
+  bookConfigEntry?.data.navigation.nextChapter ?? pageCopy.nextChapterLabel;
 
 const pageTitle = resolvedChapter?.pageTitle ?? pageCopy.title;
 const pageDescription = resolvedChapter?.summary ?? pageCopy.description;
@@ -239,7 +311,7 @@ const tocHref = `/${lang}/book/`;
     >
       <a href={homeHref}>{pageCopy.homeLabel}</a>
       <span aria-hidden="true">/</span>
-      <a href={tocHref}>{pageCopy.tocLabel}</a>
+      <a href={tocHref}>{tocLabel}</a>
       {
         resolvedChapter && (
           <>
@@ -265,107 +337,132 @@ const tocHref = `/${lang}/book/`;
 
       <p>{resolvedChapter?.summary ?? pageCopy.body}</p>
 
+      {
+        resolvedChapter && (
+          <ul
+            class="reader-route-scaffold__header-meta"
+            aria-label={pageCopy.chapterMetadataLabel}
+          >
+            <li>
+              <span>{pageCopy.audienceLabel}</span>
+              {audienceLabels[lang][resolvedChapter.audience]}
+            </li>
+            <li>
+              <span>{pageCopy.statusLabel}</span>
+              {resolvedChapter.status}
+            </li>
+          </ul>
+        )
+      }
+
       <a class="reader-route-scaffold__toc-link" href={tocHref}>
         {pageCopy.backToTocLabel}
       </a>
     </header>
 
-    <dl class="reader-route-scaffold__meta">
-      <div>
-        <dt>{pageCopy.routeLabel}</dt>
-        <dd><code>{READER_ROUTE.pattern}</code></dd>
-      </div>
+    {
+      ChapterContent ? (
+        <div class="reader-route-scaffold__body">
+          <div class="reader-route-scaffold__main">
+            <article
+              class="reader-route-scaffold__content"
+              aria-label={pageCopy.contentLabel}
+            >
+              <ChapterContent components={readerMdxComponents} />
+            </article>
 
-      <div>
-        <dt>{pageCopy.slugLabel}</dt>
-        <dd><code>{slug}</code></dd>
-      </div>
+            <footer
+              class="reader-route-scaffold__chapter-nav"
+              aria-label={pageCopy.chapterNavigationLabel}
+            >
+              {previousChapter ? (
+                <a
+                  class="reader-route-scaffold__chapter-nav-link reader-route-scaffold__chapter-nav-link--previous"
+                  href={previousChapter.href}
+                >
+                  <span class="reader-route-scaffold__chapter-nav-kicker">
+                    {previousChapterLabel}
+                  </span>
+                  <span class="reader-route-scaffold__chapter-nav-title">
+                    {previousChapter.pageTitle}
+                  </span>
+                  <span class="reader-route-scaffold__chapter-nav-context">
+                    {`${pageCopy.chapterLabel} ${previousChapter.chapterNumber} · ${previousChapter.chapterTitle}`}
+                  </span>
+                </a>
+              ) : (
+                <p class="reader-route-scaffold__chapter-nav-empty">
+                  <span class="reader-route-scaffold__chapter-nav-kicker">
+                    {previousChapterLabel}
+                  </span>
+                  <span>{pageCopy.previousChapterUnavailableLabel}</span>
+                </p>
+              )}
 
-      {
-        resolvedChapter ? (
-          <>
-            <div>
-              <dt>{pageCopy.resolvedChapterLabel}</dt>
-              <dd>
-                <code>{resolvedChapter.pageTitle}</code>
-              </dd>
-            </div>
-
-            <div>
-              <dt>{pageCopy.chapterTitleLabel}</dt>
-              <dd>
-                <code>{resolvedChapter.chapterTitle}</code>
-              </dd>
-            </div>
-
-            <div>
-              <dt>{pageCopy.statusLabel}</dt>
-              <dd>
-                <code>{resolvedChapter.status}</code>
-              </dd>
-            </div>
-
-            <div>
-              <dt>{pageCopy.audienceLabel}</dt>
-              <dd>
-                <code>{resolvedChapter.audience}</code>
-              </dd>
-            </div>
-          </>
-        ) : (
-          <div class="reader-route-scaffold__missing" role="status">
-            <dt>{pageCopy.missingTitle}</dt>
-            <dd>{pageCopy.missingBody}</dd>
+              {nextChapter ? (
+                <a
+                  class="reader-route-scaffold__chapter-nav-link reader-route-scaffold__chapter-nav-link--next"
+                  href={nextChapter.href}
+                >
+                  <span class="reader-route-scaffold__chapter-nav-kicker">
+                    {nextChapterLabel}
+                  </span>
+                  <span class="reader-route-scaffold__chapter-nav-title">
+                    {nextChapter.pageTitle}
+                  </span>
+                  <span class="reader-route-scaffold__chapter-nav-context">
+                    {`${pageCopy.chapterLabel} ${nextChapter.chapterNumber} · ${nextChapter.chapterTitle}`}
+                  </span>
+                </a>
+              ) : (
+                <p class="reader-route-scaffold__chapter-nav-empty">
+                  <span class="reader-route-scaffold__chapter-nav-kicker">
+                    {nextChapterLabel}
+                  </span>
+                  <span>{pageCopy.nextChapterUnavailableLabel}</span>
+                </p>
+              )}
+            </footer>
           </div>
-        )
-      }
-    </dl>
 
-    <div class="reader-route-scaffold__body">
-      {
-        ChapterContent && (
-          <article
-            class="reader-route-scaffold__content"
-            aria-label={pageCopy.contentLabel}
+          <aside
+            class="reader-route-scaffold__sidebar"
+            aria-labelledby="reader-sidebar-title"
           >
-            <ChapterContent />
-          </article>
-        )
-      }
+            <h2 id="reader-sidebar-title">{pageCopy.sidebarLabel}</h2>
 
-      <aside
-        class="reader-route-scaffold__sidebar"
-        aria-labelledby="reader-sidebar-title"
-      >
-        <h2 id="reader-sidebar-title">{pageCopy.sidebarLabel}</h2>
+            {readerSidebarItems.length > 0 ? (
+              <nav aria-label={pageCopy.sidebarLabel}>
+                <ol>
+                  {readerSidebarItems.map((item) => (
+                    <li>
+                      <a href={item.href}>{item.label}</a>
 
-        {
-          readerSidebarItems.length > 0 ? (
-            <nav aria-label={pageCopy.sidebarLabel}>
-              <ol>
-                {readerSidebarItems.map((item) => (
-                  <li>
-                    <a href={item.href}>{item.label}</a>
-
-                    {item.children.length > 0 && (
-                      <ol>
-                        {item.children.map((child) => (
-                          <li>
-                            <a href={child.href}>{child.label}</a>
-                          </li>
-                        ))}
-                      </ol>
-                    )}
-                  </li>
-                ))}
-              </ol>
-            </nav>
-          ) : (
-            <p>{pageCopy.emptySidebarLabel}</p>
-          )
-        }
-      </aside>
-    </div>
+                      {item.children.length > 0 && (
+                        <ol>
+                          {item.children.map((child) => (
+                            <li>
+                              <a href={child.href}>{child.label}</a>
+                            </li>
+                          ))}
+                        </ol>
+                      )}
+                    </li>
+                  ))}
+                </ol>
+              </nav>
+            ) : (
+              <p>{pageCopy.emptySidebarLabel}</p>
+            )}
+          </aside>
+        </div>
+      ) : (
+        <div class="reader-route-scaffold__missing" role="status">
+          <h2>{pageCopy.missingTitle}</h2>
+          <p>{pageCopy.missingBody}</p>
+        </div>
+      )
+    }
   </section>
 
   <script>
@@ -425,6 +522,36 @@ const tocHref = `/${lang}/book/`;
     margin: 0;
   }
 
+  .reader-route-scaffold__header-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-2);
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  .reader-route-scaffold__header-meta li {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-2);
+    min-height: 2rem;
+    padding: var(--space-1) var(--space-3);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-sm);
+    background: rgba(10, 15, 20, 0.28);
+    color: var(--muted-text-color);
+    font-family: var(--font-ui);
+    font-size: 0.85rem;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+  }
+
+  .reader-route-scaffold__header-meta span {
+    color: var(--accent-primary);
+    text-transform: uppercase;
+  }
+
   .reader-route-scaffold__toc-link {
     width: fit-content;
     font-family: var(--font-ui);
@@ -442,38 +569,17 @@ const tocHref = `/${lang}/book/`;
     color: var(--accent-primary);
   }
 
-  .reader-route-scaffold__meta {
-    display: grid;
-    gap: var(--space-3);
-    margin: 0;
-  }
-
-  .reader-route-scaffold__meta div {
-    padding: var(--space-3);
-    border: 1px solid var(--border-color);
-    border-radius: var(--radius-sm);
-    background: rgba(10, 15, 20, 0.28);
-  }
-
-  .reader-route-scaffold__meta dt {
-    margin-bottom: var(--space-1);
-    font-family: var(--font-ui);
-    font-size: 0.8rem;
-    font-weight: 700;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-    color: var(--muted-text-color);
-  }
-
-  .reader-route-scaffold__meta dd {
-    margin: 0;
-  }
-
   .reader-route-scaffold__body {
     display: grid;
     grid-template-columns: minmax(0, 1fr) minmax(12rem, 16rem);
     gap: var(--space-6);
     align-items: start;
+  }
+
+  .reader-route-scaffold__main {
+    display: grid;
+    gap: var(--space-5);
+    min-width: 0;
   }
 
   .reader-route-scaffold__sidebar {
@@ -560,7 +666,137 @@ const tocHref = `/${lang}/book/`;
     max-width: var(--reading-measure);
   }
 
+  .reader-route-scaffold__content :global([id]) {
+    scroll-margin-top: calc(5rem + var(--space-6));
+  }
+
   .reader-route-scaffold__content :global(p) {
     max-width: var(--reading-measure);
+  }
+
+  .reader-route-scaffold__chapter-nav {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: var(--space-3);
+    max-width: var(--reading-measure);
+    padding-top: var(--space-5);
+    border-top: 1px solid var(--border-color);
+  }
+
+  .reader-route-scaffold__chapter-nav-link,
+  .reader-route-scaffold__chapter-nav-empty {
+    display: grid;
+    gap: var(--space-1);
+    min-height: 7rem;
+    margin: 0;
+    padding: var(--space-4);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-sm);
+    background: rgba(10, 15, 20, 0.28);
+    color: var(--muted-text-color);
+    text-decoration: none;
+  }
+
+  .reader-route-scaffold__chapter-nav-link:hover {
+    border-color: var(--accent-primary);
+    color: var(--heading-color);
+    background: rgba(56, 189, 248, 0.1);
+  }
+
+  .reader-route-scaffold__chapter-nav-link--next {
+    text-align: right;
+  }
+
+  .reader-route-scaffold__chapter-nav-kicker {
+    font-family: var(--font-ui);
+    font-size: 0.78rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--accent-primary);
+  }
+
+  .reader-route-scaffold__chapter-nav-title {
+    font-family: var(--font-ui);
+    font-size: 1.15rem;
+    font-weight: 700;
+    line-height: 1.15;
+    color: var(--heading-color);
+  }
+
+  .reader-route-scaffold__chapter-nav-context {
+    font-family: var(--font-ui);
+    font-size: 0.85rem;
+    font-weight: 700;
+    color: var(--muted-text-color);
+  }
+
+  .reader-route-scaffold__chapter-nav-empty {
+    opacity: 0.72;
+  }
+
+  .reader-route-scaffold__missing {
+    display: grid;
+    gap: var(--space-2);
+    max-width: var(--reading-measure);
+    padding: var(--space-4);
+    border: 1px dashed var(--border-color);
+    border-radius: var(--radius-sm);
+    background: rgba(10, 15, 20, 0.24);
+  }
+
+  .reader-route-scaffold__missing h2,
+  .reader-route-scaffold__missing p {
+    margin: 0;
+  }
+
+  @media (max-width: 58rem) {
+    .reader-route-scaffold__body {
+      grid-template-columns: minmax(0, 1fr);
+      gap: var(--space-5);
+    }
+
+    .reader-route-scaffold__sidebar {
+      order: -1;
+      position: static;
+      max-height: 16rem;
+      overflow: auto;
+    }
+
+    .reader-route-scaffold__sidebar nav > ol {
+      grid-template-columns: repeat(auto-fit, minmax(12rem, 1fr));
+      align-items: start;
+    }
+  }
+
+  @media (max-width: 40rem) {
+    .reader-route-scaffold__header-meta {
+      display: grid;
+    }
+
+    .reader-route-scaffold__header-meta li {
+      width: 100%;
+    }
+
+    .reader-route-scaffold__content :global([id]) {
+      scroll-margin-top: calc(8rem + var(--space-6));
+    }
+
+    .reader-route-scaffold__chapter-nav {
+      grid-template-columns: minmax(0, 1fr);
+    }
+
+    .reader-route-scaffold__chapter-nav-link,
+    .reader-route-scaffold__chapter-nav-empty {
+      min-height: 0;
+    }
+
+    .reader-route-scaffold__chapter-nav-link--next {
+      text-align: left;
+    }
+
+    .reader-route-scaffold__sidebar {
+      max-height: 14rem;
+    }
   }
 </style>


### PR DESCRIPTION
## Summary

Completes the Phase 5 chapter reader milestone.

This adds the remaining reader behavior: responsive current-chapter navigation, previous/next chapter links from content metadata, stable heading anchors, working section links, sparse-heading safeguards, and aligned documentation for the completed milestone.

## Impact

Readers can now open generated chapter pages, read MDX content, navigate within the current chapter, move between adjacent chapters, and use direct links to chapter sections. Repository documentation now reflects Phase 5 as complete and Phase 6 as the next milestone.

## Testing

- `npm run check`
- Local validation routes:
  - `/en/book/test/test-1/`
  - `/en/book/test/test-1/#test-section`
  - `/en/book/test/test-2/`
  - `/pt-BR/book/teste/teste-1/`

Closes #75.
Closes #76.
Closes #77.
Closes #78.
Closes #79.
Closes #80.
