### PR TITLE
Add reader MDX surface and styled tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Return of the Night is an open-source web platform for reading RPG rulebooks, setting books, campaign books, and compendiums through a content-first digital-book experience.
 
-The current codebase is a plain Astro application with a shared site shell, locale-prefixed entry routes, typed content collections, initial chapter and glossary content, metadata utilities for chapter ordering and glossary lookup, a content-backed book home page with an automatically generated Table of Contents, and generated chapter reader pages with MDX rendering, current-chapter navigation, previous/next links, heading anchors, and section deep links. The next approved implementation focus is rich content support for reader pages.
+The current codebase is a plain Astro application with a shared site shell, locale-prefixed entry routes, typed content collections, initial chapter and glossary content, metadata utilities for chapter ordering and glossary lookup, a content-backed book home page with an automatically generated Table of Contents, and generated chapter reader pages with MDX rendering, current-chapter navigation, previous/next links, heading anchors, section deep links, a shared reader MDX component surface, and styled responsive Markdown table rendering. The next approved implementation focus is to continue expanding rich content support for reader pages.
 
 ## Current status
 
@@ -20,7 +20,7 @@ The current codebase is a plain Astro application with a shared site shell, loca
 - The route `/{lang}/book/` renders the current book home and Table of Contents from real content metadata.
 - The Table of Contents supports metadata-driven ordering, book-config grouping, fallback grouping for sparse localized content, chapter-reader links, empty states, orientation cues, and basic responsive behavior.
 - The route `/{lang}/book/{slug}/` renders generated chapter reader pages from content entries.
-- Chapter reader pages support plain MDX content, current-chapter sidebar navigation, previous/next chapter navigation, stable heading anchors, working section links, sparse-heading safeguards, and responsive fallback behavior.
+- Chapter reader pages support plain MDX content, current-chapter sidebar navigation, previous/next chapter navigation, stable heading anchors, working section links, sparse-heading safeguards, responsive fallback behavior, and styled responsive Markdown tables.
 - **Starlight is intentionally deferred** at this stage.
 - The repository language is **English-first** for code and contributor-facing artifacts.
 
@@ -49,10 +49,12 @@ The current codebase is a plain Astro application with a shared site shell, loca
 - `src/lib/content/chapter-routes.ts` provides chapter-reader href generation from chapter slugs.
 - `src/lib/glossary/entries.ts` provides glossary listing and lookup utilities.
 - `src/components/reader/BookTableOfContents.astro` renders the current book home and Table of Contents experience.
+- `src/components/reader/ReaderMdxContent.astro` centralizes the reader MDX component mapping used by chapter pages.
 - `src/components/reader/ReaderHeading2.astro` and `src/components/reader/ReaderHeading3.astro` render linkable reader headings for MDX content.
+- `src/components/reader/rich-content/ReaderTable.astro` renders Markdown tables with reader-specific styling and overflow-safe behavior.
 - `src/pages/[lang]/book/[...slug].astro` renders generated chapter reader pages.
 
-The app now renders the real book home, Table of Contents, and chapter reader. Interactive glossary UI, rich content blocks, full localization parity, and broader visual refinement remain planned roadmap work.
+The app now renders the real book home, Table of Contents, chapter reader, and the first reader rich-content primitive for Markdown tables. Interactive glossary UI, remaining rich content blocks, full localization parity, and broader visual refinement remain planned roadmap work.
 
 ## Source of truth
 
@@ -61,6 +63,7 @@ The documents in [`docs/`](docs/) are the source of truth for this repository.
 - [`docs/open_rulebook_platform_blueprint.md`](docs/open_rulebook_platform_blueprint.md): product vision, scope, architecture direction, and implementation roadmap for the open-source platform.
 - [`docs/return-of-the-night-source-of-truth-v0.2.md`](docs/return-of-the-night-source-of-truth-v0.2.md): setting canon and project background for Return of the Night.
 - [`docs/adr/0001-bootstrap-strategy.md`](docs/adr/0001-bootstrap-strategy.md): accepted bootstrap decision to use plain Astro and defer Starlight.
+- [`docs/adr/0002-rich-content-authoring-and-rendering-strategy.md`](docs/adr/0002-rich-content-authoring-and-rendering-strategy.md): accepted rich-content authoring and rendering strategy for reader pages.
 - [`docs/architecture.md`](docs/architecture.md): repository architecture direction, system layers, and planned implementation order.
 - [`docs/code-organization.md`](docs/code-organization.md): code organization conventions for routes, components, domain logic, and styles.
 - [`docs/assets-policy.md`](docs/assets-policy.md): repository policy for asset provenance and licensing.
@@ -120,7 +123,7 @@ The development server starts the current application shell, content-backed book
 
 The current implementation intentionally stops at a functional chapter reader. The repository does **not** yet include:
 
-- rich content blocks such as figures with captions, styled tables, columns, and callouts
+- rich content blocks such as figures with captions, columns, and callouts
 - expanded audience-conditional block rendering
 - glossary hover cards or glossary-linked reader interactions
 - full translation parity across localized content
@@ -138,7 +141,7 @@ The long-term direction is to build a maintainable RPG digital-book platform wit
 - localization support, starting with English and PT-BR
 - a writing workflow that stays close to Markdown and MDX
 
-The repository has a working foundation, base shell, content engine, book home / Table of Contents, and chapter reader. The next implementation focus is to add rich content features while preserving the Markdown/MDX-first authoring model.
+The repository has a working foundation, base shell, content engine, book home / Table of Contents, chapter reader, and styled Markdown table support. The next implementation focus is to continue adding rich content features while preserving the Markdown/MDX-first authoring model.
 
 ## Licensing
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -114,7 +114,7 @@ Current implementation status:
 - reader utilities normalize headings, build sidebar data, define reader copy, and create adjacent-reader links
 - glossary metadata utilities support listing by language and lookup by logical `id`
 - the book home renders a content-backed Table of Contents with empty states, orientation cues, and basic responsive behavior
-- the chapter reader renders MDX content, chapter-level orientation, current-chapter sidebar navigation, previous/next links, stable heading anchors, and section deep links
+- the chapter reader renders MDX content, chapter-level orientation, current-chapter sidebar navigation, previous/next links, stable heading anchors, section deep links, and styled responsive Markdown tables through a shared reader MDX component surface
 
 ## Current boundaries
 
@@ -127,17 +127,17 @@ The current implementation includes:
 - initial content seeds in English plus mirrored PT-BR examples for shared logical IDs
 - metadata utilities for chapter listing, ordering, adjacent navigation, TOC grouping, reader link generation, and glossary lookup
 - a content-backed book home / Table of Contents with empty states, orientation cues, and basic responsive behavior
-- generated chapter reader pages with plain MDX rendering, current-chapter sidebar navigation, previous/next chapter navigation, stable heading anchors, working section links, responsive fallback behavior, and sparse-heading safeguards
+- generated chapter reader pages with plain MDX rendering, current-chapter sidebar navigation, previous/next chapter navigation, stable heading anchors, working section links, responsive fallback behavior, sparse-heading safeguards, a shared reader MDX component surface, and styled responsive Markdown table rendering
 
 The current implementation does **not** yet include:
 
-- rich content blocks such as figure/caption systems, styled tables, columns, and callouts
+- rich content blocks such as figure/caption systems, columns, and callouts
 - expanded audience-conditional block rendering
 - glossary hover cards or reader-side glossary interactions
 - full translation parity or complete localization behavior
 - authentication, authorization, or backend infrastructure
 
-This means the repository now reflects the first complete content-driven reader layer of the system, while richer content blocks, glossary interactions, and localization consolidation remain planned rather than implemented.
+This means the repository now reflects the first complete content-driven reader layer of the system plus the first reader rich-content primitive for Markdown tables, while richer content blocks, glossary interactions, and localization consolidation remain planned rather than implemented.
 
 ## Planned evolution
 

--- a/src/components/reader/ChapterReader.astro
+++ b/src/components/reader/ChapterReader.astro
@@ -79,7 +79,8 @@ const {
   .chapter-reader__content {
     display: grid;
     gap: var(--space-4);
-    max-width: var(--reading-measure);
+    width: 100%;
+    min-width: 0;
     padding-top: var(--space-5);
     border-top: 1px solid var(--border-color);
   }
@@ -95,6 +96,9 @@ const {
   .chapter-reader__content :global(h1),
   .chapter-reader__content :global(h2),
   .chapter-reader__content :global(h3),
+  .chapter-reader__content :global(ul),
+  .chapter-reader__content :global(ol),
+  .chapter-reader__content :global(blockquote),
   .chapter-reader__content :global(p) {
     max-width: var(--reading-measure);
   }

--- a/src/components/reader/ReaderChapterNavigation.astro
+++ b/src/components/reader/ReaderChapterNavigation.astro
@@ -73,7 +73,7 @@ const {
     display: grid;
     grid-template-columns: repeat(2, minmax(0, 1fr));
     gap: var(--space-3);
-    max-width: var(--reading-measure);
+    width: 100%;
     padding-top: var(--space-5);
     border-top: 1px solid var(--border-color);
   }

--- a/src/components/reader/ReaderMdxContent.astro
+++ b/src/components/reader/ReaderMdxContent.astro
@@ -1,0 +1,20 @@
+---
+import ReaderHeading2 from "./ReaderHeading2.astro";
+import ReaderHeading3 from "./ReaderHeading3.astro";
+import ReaderTable from "./rich-content/ReaderTable.astro";
+import type { AstroComponentFactory } from "astro/runtime/server/index.js";
+
+interface Props {
+  Content: AstroComponentFactory;
+}
+
+const { Content } = Astro.props as Props;
+
+const readerMdxComponents = {
+  h2: ReaderHeading2,
+  h3: ReaderHeading3,
+  table: ReaderTable,
+};
+---
+
+<Content components={readerMdxComponents} />

--- a/src/components/reader/rich-content/ReaderTable.astro
+++ b/src/components/reader/rich-content/ReaderTable.astro
@@ -1,0 +1,90 @@
+---
+const tableProps = Astro.props;
+---
+
+<div
+  class="reader-table"
+  data-reader-rich-content="table"
+  role="region"
+  tabindex="0"
+  aria-label="Scrollable table"
+>
+  <table {...tableProps}>
+    <slot />
+  </table>
+</div>
+
+<style>
+  .reader-table {
+    max-width: 100%;
+    overflow-x: auto;
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-sm);
+    background: rgba(22, 27, 34, 0.42);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03);
+  }
+
+  .reader-table:focus-visible {
+    outline: 2px solid var(--focus-ring-color);
+    outline-offset: 3px;
+  }
+
+  .reader-table table {
+    width: 100%;
+    min-width: 42rem;
+    border-collapse: collapse;
+    font-size: 0.95rem;
+    line-height: 1.45;
+  }
+
+  .reader-table :global(caption) {
+    padding: var(--space-3) var(--space-4);
+    color: var(--muted-text-color);
+    font-family: var(--font-ui);
+    font-size: 0.9rem;
+    text-align: left;
+  }
+
+  .reader-table :global(th),
+  .reader-table :global(td) {
+    min-width: 9rem;
+    max-width: 22rem;
+    padding: 0.75rem 0.875rem;
+    border: 1px solid var(--border-color);
+    text-align: left;
+    vertical-align: top;
+    overflow-wrap: break-word;
+  }
+
+  .reader-table :global(th) {
+    background: rgba(34, 211, 238, 0.1);
+    color: var(--heading-color);
+    font-family: var(--font-ui);
+    font-weight: 700;
+  }
+
+  .reader-table :global(td) {
+    background: rgba(216, 225, 234, 0.025);
+  }
+
+  .reader-table :global(tbody tr:nth-child(even) td) {
+    background: rgba(216, 225, 234, 0.055);
+  }
+
+  .reader-table :global(code) {
+    white-space: nowrap;
+  }
+
+  @media (max-width: 40rem) {
+    .reader-table {
+      margin-inline: calc(var(--space-2) * -1);
+      border-radius: 0;
+    }
+
+    .reader-table :global(th),
+    .reader-table :global(td) {
+      min-width: 11rem;
+      padding: 0.7rem 0.75rem;
+    }
+  }
+</style>

--- a/src/content/chapters/en/test-1.mdx
+++ b/src/content/chapters/en/test-1.mdx
@@ -20,3 +20,10 @@ status: draft
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed non risus at
 ipsum posuere vulputate.
+
+## Table Rendering Sample
+
+| Signal                   | Reader behavior                                              | Notes                                                                              |
+| ------------------------ | ------------------------------------------------------------ | ---------------------------------------------------------------------------------- |
+| Standard Markdown table  | Renders through the shared reader MDX surface                | Authors do not need JSX for ordinary table content.                                |
+| Long tactical constraint | Keeps the table readable without breaking the reading column | This intentionally long cell helps validate horizontal overflow on narrow screens. |

--- a/src/content/chapters/pt-BR/test-1.mdx
+++ b/src/content/chapters/pt-BR/test-1.mdx
@@ -17,4 +17,11 @@ status: draft
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed non risus at
 ipsum posuere vulputate.
 
+## Amostra de renderizacao de tabela
+
+| Sinal                  | Comportamento do reader                                 | Observacoes                                                                                |
+| ---------------------- | ------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| Tabela Markdown padrao | Renderiza pela superficie MDX compartilhada do reader   | Autores nao precisam escrever JSX para tabelas comuns.                                     |
+| Restricao tatica longa | Mantem a tabela legivel sem quebrar a coluna de leitura | Esta celula intencionalmente longa ajuda a validar overflow horizontal em telas estreitas. |
+
 É pra ser isso em português.

--- a/src/pages/[lang]/book/[...slug].astro
+++ b/src/pages/[lang]/book/[...slug].astro
@@ -2,10 +2,9 @@
 import { render } from "astro:content";
 import BaseLayout from "../../../layouts/BaseLayout.astro";
 import ChapterReader from "../../../components/reader/ChapterReader.astro";
+import ReaderMdxContent from "../../../components/reader/ReaderMdxContent.astro";
 import ReaderBreadcrumb from "../../../components/reader/ReaderBreadcrumb.astro";
 import ReaderHeader from "../../../components/reader/ReaderHeader.astro";
-import ReaderHeading2 from "../../../components/reader/ReaderHeading2.astro";
-import ReaderHeading3 from "../../../components/reader/ReaderHeading3.astro";
 import ShellHeaderControls from "../../../components/ui/ShellHeaderControls.astro";
 import {
   AUDIENCES,
@@ -79,10 +78,6 @@ const chapter: ReaderChapterSummary | undefined = chapterEntry
 
 const renderedChapter = chapterEntry ? await render(chapterEntry) : undefined;
 const ChapterContent = renderedChapter?.Content;
-const readerMdxComponents = {
-  h2: ReaderHeading2,
-  h3: ReaderHeading3,
-};
 
 const readerHeadings = normalizeReaderHeadings(renderedChapter?.headings);
 const readerSidebarItems = buildReaderSidebarItems(readerHeadings);
@@ -158,7 +153,7 @@ const tocHref = `/${lang}/book/`;
       {
         ChapterContent && (
           <Fragment slot="content">
-            <ChapterContent components={readerMdxComponents} />
+            <ReaderMdxContent Content={ChapterContent} />
           </Fragment>
         )
       }


### PR DESCRIPTION
## Summary

Adds the first Phase 6 rich-content implementation batch for the chapter reader.

- centralizes reader MDX component registration in `ReaderMdxContent`
- adds `ReaderTable` for styled, responsive Markdown table rendering
- widens the reader content layout so rich blocks can use the available reading column while prose remains constrained
- adds English and PT-BR sample Markdown tables for validation
- updates README and architecture docs to link ADR 0002 and reflect current table support

Closes #95.
Closes #99.
Closes #100.

## Validation

- `npm run check`
- local visual validation on `/en/book/test/test-1/` and `/pt-BR/book/teste/teste-1/`

## Notes

The PR is intentionally draft for local review before marking it ready.