### PR TITLE
Add directive columns layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ The development server starts the current application shell, content-backed book
 
 The current implementation intentionally stops at a functional chapter reader. The repository does **not** yet include:
 
-- rich content blocks such as columns and callouts
+- rich content blocks such as callouts
 - expanded audience-conditional block rendering
 - glossary hover cards or glossary-linked reader interactions
 - full translation parity across localized content
@@ -142,7 +142,7 @@ The long-term direction is to build a maintainable RPG digital-book platform wit
 - localization support, starting with English and PT-BR
 - a writing workflow that stays close to Markdown and MDX
 
-The repository has a working foundation, base shell, content engine, book home / Table of Contents, chapter reader, semantic figure support, and styled Markdown table support. The next implementation focus is to continue adding rich content features while preserving the Markdown/MDX-first authoring model.
+The repository has a working foundation, base shell, content engine, book home / Table of Contents, chapter reader, semantic figure support, styled Markdown table support, and directive-authored columns with responsive reader rendering. The next implementation focus is to continue adding rich content features while preserving the Markdown/MDX-first authoring model.
 
 ## Licensing
 

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,13 +1,19 @@
 import { defineConfig } from "astro/config";
 
 import mdx from "@astrojs/mdx";
+import remarkDirective from "remark-directive";
+import { remarkReaderColumns } from "./src/lib/reader/rich-content/remark-reader-columns.mjs";
 import { remarkReaderFigures } from "./src/lib/reader/rich-content/remark-reader-figures.mjs";
 
 // https://astro.build/config
 export default defineConfig({
   integrations: [
     mdx({
-      remarkPlugins: [remarkReaderFigures],
+      remarkPlugins: [
+        remarkDirective,
+        remarkReaderColumns,
+        remarkReaderFigures,
+      ],
     }),
   ],
 });

--- a/docs/adr/0002-rich-content-authoring-and-rendering-strategy.md
+++ b/docs/adr/0002-rich-content-authoring-and-rendering-strategy.md
@@ -30,7 +30,7 @@ The implementation will use a hybrid strategy:
 
 - Standard Markdown tables should remain the authoring convention for tables, with reader-specific semantic rendering and styling applied by the site.
 - Figures with captions should use an author-friendly block convention, rendered internally as semantic figure content.
-- Columns should use an author-friendly block convention for side-by-side composition, rendered internally through reader layout components.
+- Columns should use an author-friendly block convention for side-by-side composition, rendered internally through reader-owned layout markup.
 - Callouts should use an author-friendly block convention with a minimal supported set of variants.
 - Audience-filtered blocks should use an explicit authoring convention connected to the existing reader audience preference.
 
@@ -48,6 +48,23 @@ _Caption: Existing registered project artwork reused to validate semantic figure
 Localized content may use `Legenda:` instead of `Caption:` for the caption marker.
 
 The reader transforms this pair into semantic figure content internally. Authors should not write figure JSX for ordinary image-plus-caption content.
+
+## Current columns convention
+
+Side-by-side content uses directive-style Markdown blocks:
+
+```md
+:::columns
+:::column
+Rules text, lists, or tables go here.
+:::
+:::column
+Image, table, or supporting text goes here.
+:::
+:::
+```
+
+The reader transforms supported `columns` / `column` directives into reader-owned layout markup internally. Authors should not write layout JSX for ordinary two-column composition.
 
 ## Audience filtering
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -114,7 +114,7 @@ Current implementation status:
 - reader utilities normalize headings, build sidebar data, define reader copy, and create adjacent-reader links
 - glossary metadata utilities support listing by language and lookup by logical `id`
 - the book home renders a content-backed Table of Contents with empty states, orientation cues, and basic responsive behavior
-- the chapter reader renders MDX content, chapter-level orientation, current-chapter sidebar navigation, previous/next links, stable heading anchors, section deep links, semantic figures with captions, and styled responsive Markdown tables through a shared reader MDX component surface
+- the chapter reader renders MDX content, chapter-level orientation, current-chapter sidebar navigation, previous/next links, stable heading anchors, section deep links, semantic figures with captions, styled responsive Markdown tables, and directive-authored responsive columns through a shared reader MDX component surface
 
 ## Current boundaries
 
@@ -127,17 +127,17 @@ The current implementation includes:
 - initial content seeds in English plus mirrored PT-BR examples for shared logical IDs
 - metadata utilities for chapter listing, ordering, adjacent navigation, TOC grouping, reader link generation, and glossary lookup
 - a content-backed book home / Table of Contents with empty states, orientation cues, and basic responsive behavior
-- generated chapter reader pages with plain MDX rendering, current-chapter sidebar navigation, previous/next chapter navigation, stable heading anchors, working section links, responsive fallback behavior, sparse-heading safeguards, a shared reader MDX component surface, semantic figure rendering, and styled responsive Markdown table rendering
+- generated chapter reader pages with plain MDX rendering, current-chapter sidebar navigation, previous/next chapter navigation, stable heading anchors, working section links, responsive fallback behavior, sparse-heading safeguards, a shared reader MDX component surface, semantic figure rendering, styled responsive Markdown table rendering, and responsive reader column rendering
 
 The current implementation does **not** yet include:
 
-- rich content blocks such as columns and callouts
+- rich content blocks such as callouts
 - expanded audience-conditional block rendering
 - glossary hover cards or reader-side glossary interactions
 - full translation parity or complete localization behavior
 - authentication, authorization, or backend infrastructure
 
-This means the repository now reflects the first complete content-driven reader layer of the system plus the first reader rich-content primitives for semantic figures and Markdown tables, while richer content blocks, glossary interactions, and localization consolidation remain planned rather than implemented.
+This means the repository now reflects the first complete content-driven reader layer of the system plus the first reader rich-content primitives for semantic figures, Markdown tables, and responsive columns, while callouts, audience blocks, glossary interactions, and localization consolidation remain planned rather than implemented.
 
 ## Planned evolution
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,10 +7,11 @@
     "": {
       "name": "return-of-the-night",
       "version": "1.0.0",
-      "license": "ISC",
+      "license": "MIT",
       "dependencies": {
         "@astrojs/mdx": "^5.0.3",
-        "astro": "^6.0.7"
+        "astro": "^6.0.7",
+        "remark-directive": "^4.0.0"
       },
       "devDependencies": {
         "@astrojs/check": "^0.9.8",
@@ -4755,6 +4756,27 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/mdast-util-directive": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-directive/-/mdast-util-directive-3.1.0.tgz",
+      "integrity": "sha512-I3fNFt+DHmpWCYAT7quoM6lHf9wuqtI+oCOfvILnoicNIqjh5E3dEJWiXuYME2gNe8vl1iMQwyUHa7bgFmak6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdast-util-find-and-replace": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
@@ -5125,6 +5147,25 @@
         "micromark-util-subtokenize": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-directive": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-directive/-/micromark-extension-directive-4.0.0.tgz",
+      "integrity": "sha512-/C2nqVmXXmiseSSuCdItCMho7ybwwop6RrrRPk0KbOHW21JKoCldC+8rFOaundDoRBUWBnJJcxeA/Kvi34WQXg==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "parse-entities": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/micromark-extension-gfm": {
@@ -6514,6 +6555,22 @@
       "dependencies": {
         "@types/hast": "^3.0.0",
         "hast-util-to-html": "^9.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-directive": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/remark-directive/-/remark-directive-4.0.0.tgz",
+      "integrity": "sha512-7sxn4RfF1o3izevPV1DheyGDD6X4c9hrGpfdUpm7uC++dqrnJxIZVkk7CoKqcLm0VUMAuOol7Mno3m6g8cfMuA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-directive": "^3.0.0",
+        "micromark-extension-directive": "^4.0.0",
         "unified": "^11.0.0"
       },
       "funding": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
   "packageManager": "npm@11.7.0",
   "dependencies": {
     "@astrojs/mdx": "^5.0.3",
-    "astro": "^6.0.7"
+    "astro": "^6.0.7",
+    "remark-directive": "^4.0.0"
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.8",

--- a/src/components/reader/ReaderMdxContent.astro
+++ b/src/components/reader/ReaderMdxContent.astro
@@ -20,3 +20,33 @@ const readerMdxComponents = {
 ---
 
 <Content components={readerMdxComponents} />
+
+<style>
+  :global(.reader-columns) {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: var(--space-4);
+    align-items: start;
+    width: 100%;
+    margin-block: var(--space-5);
+  }
+
+  :global(.reader-column) {
+    min-width: 0;
+  }
+
+  :global(.reader-column > :first-child) {
+    margin-top: 0;
+  }
+
+  :global(.reader-column > :last-child) {
+    margin-bottom: 0;
+  }
+
+  @media (max-width: 48rem) {
+    :global(.reader-columns) {
+      grid-template-columns: minmax(0, 1fr);
+      gap: var(--space-3);
+    }
+  }
+</style>

--- a/src/components/reader/rich-content/ReaderTable.astro
+++ b/src/components/reader/rich-content/ReaderTable.astro
@@ -75,6 +75,20 @@ const tableProps = Astro.props;
     white-space: nowrap;
   }
 
+  :global(.reader-column) .reader-table table {
+    min-width: 100%;
+    table-layout: fixed;
+    font-size: 0.9rem;
+  }
+
+  :global(.reader-column) .reader-table :global(th),
+  :global(.reader-column) .reader-table :global(td) {
+    min-width: 0;
+    max-width: none;
+    padding: 0.65rem 0.75rem;
+    overflow-wrap: anywhere;
+  }
+
   @media (max-width: 40rem) {
     .reader-table {
       margin-inline: calc(var(--space-2) * -1);

--- a/src/content/chapters/en/test-1.mdx
+++ b/src/content/chapters/en/test-1.mdx
@@ -32,3 +32,21 @@ _Caption: Existing registered project artwork reused to validate semantic figure
 | ------------------------ | ------------------------------------------------------------ | ---------------------------------------------------------------------------------- |
 | Standard Markdown table  | Renders through the shared reader MDX surface                | Authors do not need JSX for ordinary table content.                                |
 | Long tactical constraint | Keeps the table readable without breaking the reading column | This intentionally long cell helps validate horizontal overflow on narrow screens. |
+
+## Columns Rendering Sample
+
+:::columns
+:::column
+This column keeps ordinary Markdown authoring.
+
+- Supports paragraphs and lists.
+- Preserves the source reading order.
+
+:::
+:::column
+| Checkpoint | Outcome |
+| ---------- | ------- |
+| Wide view | Columns render side by side. |
+| Narrow view | Columns stack in source order. |
+:::
+:::

--- a/src/content/chapters/pt-BR/test-1.mdx
+++ b/src/content/chapters/pt-BR/test-1.mdx
@@ -29,4 +29,22 @@ _Legenda: Arte ja registrada do projeto reutilizada para validar renderizacao se
 | Tabela Markdown padrao | Renderiza pela superficie MDX compartilhada do reader   | Autores nao precisam escrever JSX para tabelas comuns.                                     |
 | Restricao tatica longa | Mantem a tabela legivel sem quebrar a coluna de leitura | Esta celula intencionalmente longa ajuda a validar overflow horizontal em telas estreitas. |
 
+## Amostra de renderizacao de colunas
+
+:::columns
+:::column
+Esta coluna mantem a autoria em Markdown comum.
+
+- Suporta paragrafos e listas.
+- Preserva a ordem de leitura do arquivo.
+
+:::
+:::column
+| Checagem | Resultado |
+| -------- | --------- |
+| Tela larga | As colunas aparecem lado a lado. |
+| Tela estreita | As colunas empilham na ordem do arquivo. |
+:::
+:::
+
 É pra ser isso em português.

--- a/src/lib/content/reader-conventions.ts
+++ b/src/lib/content/reader-conventions.ts
@@ -56,7 +56,6 @@ export const READER_CORE_SCOPE = [
 ] as const;
 
 export const READER_DEFERRED_SCOPE = [
-  "columns",
   "callouts",
   "expanded-audience-conditional-block-rendering",
   "glossary-hover-cards",

--- a/src/lib/reader/rich-content/conventions.ts
+++ b/src/lib/reader/rich-content/conventions.ts
@@ -11,6 +11,10 @@ export type SupportedRichContentBlockType =
 
 export const FIGURE_CAPTION_PREFIXES = ["Caption", "Legenda"] as const;
 
+export const COLUMNS_DIRECTIVE_NAME = "columns" as const;
+
+export const COLUMN_DIRECTIVE_NAME = "column" as const;
+
 export const SUPPORTED_AUDIENCE_BLOCK_TARGETS = ["player", "gm"] as const;
 
 export type SupportedAudienceBlockTarget =

--- a/src/lib/reader/rich-content/remark-reader-columns.mjs
+++ b/src/lib/reader/rich-content/remark-reader-columns.mjs
@@ -1,0 +1,100 @@
+function isColumnsDirective(node) {
+  return node?.type === "containerDirective" && node.name === "columns";
+}
+
+function isColumnDirective(node) {
+  return node?.type === "containerDirective" && node.name === "column";
+}
+
+function isDirectiveClosingParagraph(node) {
+  return (
+    node?.type === "paragraph" &&
+    node.children?.length === 1 &&
+    node.children[0]?.type === "text" &&
+    node.children[0].value.trim() === ":::"
+  );
+}
+
+function setElementName(node, elementName, elementProperties = {}) {
+  node.data = {
+    ...node.data,
+    hName: elementName,
+    hProperties: {
+      ...node.data?.hProperties,
+      ...elementProperties,
+    },
+  };
+}
+
+function transformColumnDirective(node) {
+  setElementName(node, "div", {
+    className: ["reader-column"],
+    "data-reader-rich-content": "column",
+  });
+}
+
+function collectColumnSiblings(parent, startIndex) {
+  const columnsNode = parent.children[startIndex];
+  const followingColumns = [];
+  let cursor = startIndex + 1;
+
+  while (isColumnDirective(parent.children[cursor])) {
+    followingColumns.push(parent.children[cursor]);
+    cursor += 1;
+  }
+
+  const hasClosingParagraph = isDirectiveClosingParagraph(
+    parent.children[cursor],
+  );
+  const deleteCount = followingColumns.length + (hasClosingParagraph ? 1 : 0);
+
+  if (deleteCount > 0) {
+    parent.children.splice(startIndex + 1, deleteCount);
+  }
+
+  columnsNode.children = [...(columnsNode.children ?? []), ...followingColumns];
+}
+
+function transformColumnsDirective(parent, index) {
+  const columnsNode = parent.children[index];
+
+  collectColumnSiblings(parent, index);
+
+  setElementName(columnsNode, "div", {
+    className: ["reader-columns"],
+    "data-reader-rich-content": "columns",
+  });
+
+  columnsNode.children = (columnsNode.children ?? []).filter((child) =>
+    isColumnDirective(child),
+  );
+
+  for (const child of columnsNode.children) {
+    transformColumnDirective(child);
+  }
+}
+
+function transformColumns(parent) {
+  if (!Array.isArray(parent?.children)) return;
+
+  for (let index = 0; index < parent.children.length; index += 1) {
+    const child = parent.children[index];
+
+    if (isColumnsDirective(child)) {
+      transformColumnsDirective(parent, index);
+      continue;
+    }
+
+    if (isColumnDirective(child)) {
+      transformColumnDirective(child);
+    }
+
+    transformColumns(child);
+  }
+}
+
+export function remarkReaderColumns() {
+  return function transform(tree) {
+    transformColumns(tree);
+  };
+}

--- a/src/lib/reader/rich-content/remark-reader-figures.mjs
+++ b/src/lib/reader/rich-content/remark-reader-figures.mjs
@@ -115,5 +115,9 @@ function transformFigurePairs(parent) {
 export function remarkReaderFigures() {
   return function transform(tree) {
     transformFigurePairs(tree);
+
+    for (const child of tree.children ?? []) {
+      transform(child);
+    }
   };
 }


### PR DESCRIPTION
## Summary

Adds the Phase 6 columns batch for reader rich content:

- adds `remark-directive` and a reader transform for the approved `:::columns` / `:::column` authoring convention
- renders recognized columns as reader-owned layout markup with responsive side-by-side behavior
- stacks columns on smaller screens while preserving source reading order
- keeps tables inside columns compact so they do not force horizontal scrolling in ordinary two-column layouts
- updates EN/PT-BR sample chapter content and project docs to reflect implemented columns support

Closes #101.
Closes #102.
Closes #103.

## Validation

- `npm run check`
- verified built EN/PT-BR chapter HTML contains `reader-columns` / `reader-column` markup
- verified generated CSS includes the compact table override for tables nested inside reader columns