### PR TITLE
feat(reader): render callout blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,6 @@ The development server starts the current application shell, content-backed book
 
 The current implementation intentionally stops at a functional chapter reader. The repository does **not** yet include:
 
-- rich content blocks such as callouts
 - expanded audience-conditional block rendering
 - glossary hover cards or glossary-linked reader interactions
 - full translation parity across localized content
@@ -142,7 +141,7 @@ The long-term direction is to build a maintainable RPG digital-book platform wit
 - localization support, starting with English and PT-BR
 - a writing workflow that stays close to Markdown and MDX
 
-The repository has a working foundation, base shell, content engine, book home / Table of Contents, chapter reader, semantic figure support, styled Markdown table support, and directive-authored columns with responsive reader rendering. The next implementation focus is to continue adding rich content features while preserving the Markdown/MDX-first authoring model.
+The repository has a working foundation, base shell, content engine, book home / Table of Contents, chapter reader, semantic figure support, styled Markdown table support, directive-authored columns with responsive reader rendering, and semantic reader callouts. The next implementation focus is to continue adding rich content features while preserving the Markdown/MDX-first authoring model.
 
 ## Licensing
 

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -2,6 +2,7 @@ import { defineConfig } from "astro/config";
 
 import mdx from "@astrojs/mdx";
 import remarkDirective from "remark-directive";
+import { remarkReaderCallouts } from "./src/lib/reader/rich-content/remark-reader-callouts.mjs";
 import { remarkReaderColumns } from "./src/lib/reader/rich-content/remark-reader-columns.mjs";
 import { remarkReaderFigures } from "./src/lib/reader/rich-content/remark-reader-figures.mjs";
 
@@ -11,6 +12,7 @@ export default defineConfig({
     mdx({
       remarkPlugins: [
         remarkDirective,
+        remarkReaderCallouts,
         remarkReaderColumns,
         remarkReaderFigures,
       ],

--- a/docs/adr/0002-rich-content-authoring-and-rendering-strategy.md
+++ b/docs/adr/0002-rich-content-authoring-and-rendering-strategy.md
@@ -66,6 +66,34 @@ Image, table, or supporting text goes here.
 
 The reader transforms supported `columns` / `column` directives into reader-owned layout markup internally. Authors should not write layout JSX for ordinary two-column composition.
 
+## Current callout convention
+
+Callouts use directive-style Markdown blocks with an intentionally limited variant set:
+
+```md
+:::note
+Supporting context goes here.
+:::
+
+:::warning
+Important caution goes here.
+:::
+
+:::example
+Short applied example goes here.
+:::
+```
+
+Localized content may provide an explicit visible label:
+
+```md
+:::warning[Aviso]
+Localized warning text goes here.
+:::
+```
+
+The reader transforms supported `note`, `warning`, and `example` directives into reader-owned semantic callout markup. Authors should not write callout JSX for ordinary note, warning, or example blocks.
+
 ## Audience filtering
 
 Audience-filtered content is a reading preference, not a security feature.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -127,17 +127,16 @@ The current implementation includes:
 - initial content seeds in English plus mirrored PT-BR examples for shared logical IDs
 - metadata utilities for chapter listing, ordering, adjacent navigation, TOC grouping, reader link generation, and glossary lookup
 - a content-backed book home / Table of Contents with empty states, orientation cues, and basic responsive behavior
-- generated chapter reader pages with plain MDX rendering, current-chapter sidebar navigation, previous/next chapter navigation, stable heading anchors, working section links, responsive fallback behavior, sparse-heading safeguards, a shared reader MDX component surface, semantic figure rendering, styled responsive Markdown table rendering, and responsive reader column rendering
+- generated chapter reader pages with plain MDX rendering, current-chapter sidebar navigation, previous/next chapter navigation, stable heading anchors, working section links, responsive fallback behavior, sparse-heading safeguards, a shared reader MDX component surface, semantic figure rendering, styled responsive Markdown table rendering, responsive reader column rendering, and semantic callout rendering
 
 The current implementation does **not** yet include:
 
-- rich content blocks such as callouts
 - expanded audience-conditional block rendering
 - glossary hover cards or reader-side glossary interactions
 - full translation parity or complete localization behavior
 - authentication, authorization, or backend infrastructure
 
-This means the repository now reflects the first complete content-driven reader layer of the system plus the first reader rich-content primitives for semantic figures, Markdown tables, and responsive columns, while callouts, audience blocks, glossary interactions, and localization consolidation remain planned rather than implemented.
+This means the repository now reflects the first complete content-driven reader layer of the system plus the first reader rich-content primitives for semantic figures, Markdown tables, responsive columns, and callouts, while audience blocks, glossary interactions, and localization consolidation remain planned rather than implemented.
 
 ## Planned evolution
 

--- a/src/components/reader/ReaderMdxContent.astro
+++ b/src/components/reader/ReaderMdxContent.astro
@@ -22,6 +22,55 @@ const readerMdxComponents = {
 <Content components={readerMdxComponents} />
 
 <style>
+  :global(.reader-callout) {
+    display: grid;
+    gap: var(--space-2);
+    width: 100%;
+    margin-block: var(--space-5);
+    padding: var(--space-4);
+    border: 1px solid var(--reader-callout-border, var(--border-color));
+    border-left-width: 0.35rem;
+    border-radius: var(--radius-sm);
+    background: var(--reader-callout-background, rgba(10, 15, 20, 0.34));
+  }
+
+  :global(.reader-callout--note) {
+    --reader-callout-accent: var(--accent-primary);
+    --reader-callout-background: rgba(34, 211, 238, 0.07);
+    --reader-callout-border: rgba(34, 211, 238, 0.34);
+  }
+
+  :global(.reader-callout--warning) {
+    --reader-callout-accent: var(--accent-warning);
+    --reader-callout-background: rgba(250, 204, 21, 0.08);
+    --reader-callout-border: rgba(250, 204, 21, 0.38);
+  }
+
+  :global(.reader-callout--example) {
+    --reader-callout-accent: var(--accent-secondary);
+    --reader-callout-background: rgba(247, 37, 133, 0.07);
+    --reader-callout-border: rgba(247, 37, 133, 0.32);
+  }
+
+  :global(.reader-callout > * + *) {
+    margin-top: 0;
+  }
+
+  :global(.reader-callout__label) {
+    margin: 0;
+    color: var(--reader-callout-accent, var(--accent-primary));
+    font-family: var(--font-ui);
+    font-size: 0.85rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    line-height: 1.15;
+    text-transform: uppercase;
+  }
+
+  :global(.reader-callout > :last-child) {
+    margin-bottom: 0;
+  }
+
   :global(.reader-columns) {
     display: grid;
     grid-template-columns: repeat(2, minmax(0, 1fr));

--- a/src/content/chapters/en/test-1.mdx
+++ b/src/content/chapters/en/test-1.mdx
@@ -50,3 +50,17 @@ This column keeps ordinary Markdown authoring.
 | Narrow view | Columns stack in source order. |
 :::
 :::
+
+## Callout Rendering Sample
+
+:::note
+Use note callouts for supporting context that should stand apart from ordinary paragraph flow.
+:::
+
+:::warning
+Use warning callouts when the reader should pay attention before applying a rule or procedure.
+:::
+
+:::example
+Example callouts can show a short rule application without making authors write custom JSX.
+:::

--- a/src/content/chapters/pt-BR/test-1.mdx
+++ b/src/content/chapters/pt-BR/test-1.mdx
@@ -47,4 +47,18 @@ Esta coluna mantem a autoria em Markdown comum.
 :::
 :::
 
+## Amostra de renderizacao de chamadas
+
+:::note[Nota]
+Use chamadas de nota para contexto de apoio que precisa ficar separado do fluxo comum do texto.
+:::
+
+:::warning[Aviso]
+Use chamadas de aviso quando a pessoa leitora deve prestar atencao antes de aplicar uma regra ou procedimento.
+:::
+
+:::example[Exemplo]
+Chamadas de exemplo podem mostrar uma aplicacao curta de regra sem exigir JSX customizado de autores.
+:::
+
 É pra ser isso em português.

--- a/src/lib/content/reader-conventions.ts
+++ b/src/lib/content/reader-conventions.ts
@@ -56,7 +56,6 @@ export const READER_CORE_SCOPE = [
 ] as const;
 
 export const READER_DEFERRED_SCOPE = [
-  "callouts",
   "expanded-audience-conditional-block-rendering",
   "glossary-hover-cards",
   "localization-consolidation-or-fallback-logic",

--- a/src/lib/reader/rich-content/conventions.ts
+++ b/src/lib/reader/rich-content/conventions.ts
@@ -15,6 +15,8 @@ export const COLUMNS_DIRECTIVE_NAME = "columns" as const;
 
 export const COLUMN_DIRECTIVE_NAME = "column" as const;
 
+export const CALLOUT_DIRECTIVE_NAMES = ["note", "warning", "example"] as const;
+
 export const SUPPORTED_AUDIENCE_BLOCK_TARGETS = ["player", "gm"] as const;
 
 export type SupportedAudienceBlockTarget =

--- a/src/lib/reader/rich-content/remark-reader-callouts.mjs
+++ b/src/lib/reader/rich-content/remark-reader-callouts.mjs
@@ -1,0 +1,92 @@
+const CALLOUT_LABELS = {
+  example: "Example",
+  note: "Note",
+  warning: "Warning",
+};
+
+function isCalloutDirective(node) {
+  return (
+    node?.type === "containerDirective" &&
+    Object.hasOwn(CALLOUT_LABELS, node.name)
+  );
+}
+
+function getTextContent(node) {
+  if (node?.type === "text") return node.value;
+  if (!Array.isArray(node?.children)) return "";
+
+  return node.children.map((child) => getTextContent(child)).join("");
+}
+
+function getDirectiveLabel(node) {
+  const firstChild = node.children?.[0];
+
+  if (!firstChild?.data?.directiveLabel) {
+    return {
+      children: [{ type: "text", value: CALLOUT_LABELS[node.name] }],
+      text: CALLOUT_LABELS[node.name],
+    };
+  }
+
+  node.children.shift();
+
+  return {
+    children: firstChild.children ?? [
+      { type: "text", value: CALLOUT_LABELS[node.name] },
+    ],
+    text: getTextContent(firstChild).trim() || CALLOUT_LABELS[node.name],
+  };
+}
+
+function createCalloutLabelNode(labelChildren) {
+  return {
+    type: "paragraph",
+    data: {
+      hName: "p",
+      hProperties: {
+        className: ["reader-callout__label"],
+      },
+    },
+    children: labelChildren,
+  };
+}
+
+function transformCalloutDirective(node) {
+  const label = getDirectiveLabel(node);
+
+  node.data = {
+    ...node.data,
+    hName: "aside",
+    hProperties: {
+      ...node.data?.hProperties,
+      "aria-label": label.text,
+      className: ["reader-callout", `reader-callout--${node.name}`],
+      "data-reader-callout": node.name,
+      "data-reader-rich-content": "callout",
+      role: "note",
+    },
+  };
+
+  node.children = [
+    createCalloutLabelNode(label.children),
+    ...(node.children ?? []),
+  ];
+}
+
+function transformCallouts(parent) {
+  if (!Array.isArray(parent?.children)) return;
+
+  for (const child of parent.children) {
+    if (isCalloutDirective(child)) {
+      transformCalloutDirective(child);
+    }
+
+    transformCallouts(child);
+  }
+}
+
+export function remarkReaderCallouts() {
+  return function transform(tree) {
+    transformCallouts(tree);
+  };
+}


### PR DESCRIPTION
## Summary

Adds author-facing callout block support to chapter content and renders supported callouts as semantic reader elements.

This introduces directive-authored `note`, `warning`, and `example` callouts, wires the callout transformer into the MDX pipeline, adds reader-safe presentation styles, and updates real chapter samples to exercise the supported callout variants.

## Changes

- Adds `remarkReaderCallouts` to transform supported callout directives into reader-owned semantic markup.
- Registers the callout transformer in the Astro MDX pipeline.
- Supports `:::note`, `:::warning`, and `:::example` callout blocks.
- Supports explicit visible labels such as `:::warning[Aviso]` for localized content.
- Adds semantic callout output with `aside`, `role="note"`, `aria-label`, visible labels, variant classes, and reader data attributes.
- Adds consistent reader styling for note, warning, and example callout variants.
- Documents the current callout authoring convention in ADR 0002.
- Adds real EN and PT-BR chapter samples covering all supported callout variants.
- Removes `callouts` from the deferred reader scope now that basic callout support is implemented.

## Scope boundaries

This PR intentionally does not implement:

- additional callout variants beyond `note`, `warning`, and `example`
- nested or advanced callout layouts beyond the supported directive convention
- audience-conditional block rendering
- glossary hover cards or inline glossary interactions
- localization fallback behavior
- broad reader visual redesign
- access control for audience-filtered content

## Verification

- [x] `npm run check`
- [x] Manually checked `/en/book/test/test-1/`
- [x] Manually checked `/pt-BR/book/teste/teste-1/`
- [x] Confirmed `note`, `warning`, and `example` callouts render as distinct reader elements.
- [x] Confirmed localized callout labels render from directive labels.
- [x] Confirmed ordinary Markdown inside callouts remains readable in source content.

Closes #104.
Closes #105.